### PR TITLE
Use isGlobal flag for update-notifier

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -38,7 +38,7 @@ const notifier = updateNotifier({
   pkg,
   updateCheckInterval: 1000 * 60 * 15 // 15 minutes
 });
-notifier.notify();
+notifier.notify({isGlobal: true});
 
 yargs(hideBin(process.argv))
   .scriptName("saleor")


### PR DESCRIPTION
To prevent misleading package update command