### PR TITLE
Add links for npm page

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.3.0",
   "description": "",
   "type": "module",
+  "repository": "github:saleor/saleor-cli",
+  "homepage": "https://github.com/saleor/saleor-cli#readme",
+  "bugs": "https://github.com/saleor/saleor-cli/issues",
   "bin": {
     "saleor": "./build/cli.js"
   },


### PR DESCRIPTION
I want to merge this because this PR adds links in `package.json` that make it possible to display links inside npm pacakge page

For example see [Material UI](https://www.npmjs.com/package/@material-ui/core):

<img width="428" alt="CleanShot 2022-06-07 at 13 44 56@2x" src="https://user-images.githubusercontent.com/4144459/172371589-e6ddc6e3-48f4-48bb-8bfe-1d51fa073e88.png">
