### PR TITLE
Temporary support of both - new and old envnames

### DIFF
--- a/src/cli/app/deploy.ts
+++ b/src/cli/app/deploy.ts
@@ -75,7 +75,19 @@ export const handler = async (argv: Arguments<Options>) => {
       type: 'plain',
     },
     {
+      key: 'SALEOR_REGISTER_APP_URL',
+      value: 'https://appraptor.deno.dev/register?cloud=vercel',
+      target: ['production', 'preview'],
+      type: 'plain',
+    },
+    {
       key: 'SALEOR_MARKETPLACE_TOKEN',
+      value: encrypted,
+      target: ['production', 'preview'],
+      type: 'plain',
+    },
+    {
+      key: 'SALEOR_DEPLOYMENT_TOKEN',
       value: encrypted,
       target: ['production', 'preview'],
       type: 'plain',


### PR DESCRIPTION
That's blocking https://github.com/saleor/saleor-app-template/pull/56

(separate question is where actually point, when registering app in denver)