### PR TITLE
Use the project domain, not deployment domain

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -161,9 +161,9 @@ packages:
     dependencies:
       '@babel/core': 7.18.10
       '@babel/generator': 7.18.10
-      '@babel/parser': 7.18.10
+      '@babel/parser': 7.18.11
       '@babel/runtime': 7.18.9
-      '@babel/traverse': 7.18.10
+      '@babel/traverse': 7.18.11
       '@babel/types': 7.18.10
       babel-preset-fbjs: 3.4.0_@babel+core@7.18.10
       chalk: 4.1.2
@@ -2179,9 +2179,9 @@ packages:
       '@babel/helper-compilation-targets': 7.18.9_@babel+core@7.18.10
       '@babel/helper-module-transforms': 7.18.9
       '@babel/helpers': 7.18.9
-      '@babel/parser': 7.18.10
+      '@babel/parser': 7.18.11
       '@babel/template': 7.18.10
-      '@babel/traverse': 7.18.10
+      '@babel/traverse': 7.18.11
       '@babel/types': 7.18.10
       convert-source-map: 1.8.0
       debug: 4.3.4
@@ -2292,7 +2292,7 @@ packages:
       '@babel/helper-split-export-declaration': 7.18.6
       '@babel/helper-validator-identifier': 7.18.6
       '@babel/template': 7.18.10
-      '@babel/traverse': 7.18.10
+      '@babel/traverse': 7.18.11
       '@babel/types': 7.18.10
     transitivePeerDependencies:
       - supports-color
@@ -2317,7 +2317,7 @@ packages:
       '@babel/helper-environment-visitor': 7.18.9
       '@babel/helper-member-expression-to-functions': 7.18.9
       '@babel/helper-optimise-call-expression': 7.18.6
-      '@babel/traverse': 7.18.10
+      '@babel/traverse': 7.18.11
       '@babel/types': 7.18.10
     transitivePeerDependencies:
       - supports-color
@@ -2364,7 +2364,7 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/template': 7.18.10
-      '@babel/traverse': 7.18.10
+      '@babel/traverse': 7.18.11
       '@babel/types': 7.18.10
     transitivePeerDependencies:
       - supports-color
@@ -2379,8 +2379,8 @@ packages:
       js-tokens: 4.0.0
     dev: true
 
-  /@babel/parser/7.18.10:
-    resolution: {integrity: sha512-TYk3OA0HKL6qNryUayb5UUEhM/rkOQozIBEA5ITXh5DWrSp0TlUQXMyZmnWxG/DizSWBeeQ0Zbc5z8UGaaqoeg==}
+  /@babel/parser/7.18.11:
+    resolution: {integrity: sha512-9JKn5vN+hDt0Hdqn1PiJ2guflwP+B6Ga8qbDuoF0PzzVhrzsKIJo8yGqVk6CmMHiMei9w1C1Bp9IMJSIK+HPIQ==}
     engines: {node: '>=6.0.0'}
     hasBin: true
     dependencies:
@@ -2705,12 +2705,12 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/code-frame': 7.18.6
-      '@babel/parser': 7.18.10
+      '@babel/parser': 7.18.11
       '@babel/types': 7.18.10
     dev: true
 
-  /@babel/traverse/7.18.10:
-    resolution: {integrity: sha512-J7ycxg0/K9XCtLyHf0cz2DqDihonJeIo+z+HEdRe9YuT8TY4A66i+Ab2/xZCEW7Ro60bPCBBfqqboHSamoV3+g==}
+  /@babel/traverse/7.18.11:
+    resolution: {integrity: sha512-TG9PiM2R/cWCAy6BPJKeHzNbu4lPzOSZpeMfeNErskGpTJx6trEvFaVCbDvpcxwy49BKWmEPwiW8mrysNiDvIQ==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/code-frame': 7.18.6
@@ -2719,7 +2719,7 @@ packages:
       '@babel/helper-function-name': 7.18.9
       '@babel/helper-hoist-variables': 7.18.6
       '@babel/helper-split-export-declaration': 7.18.6
-      '@babel/parser': 7.18.10
+      '@babel/parser': 7.18.11
       '@babel/types': 7.18.10
       debug: 4.3.4
       globals: 11.12.0
@@ -2999,8 +2999,8 @@ packages:
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
     dependencies:
-      '@babel/parser': 7.18.10
-      '@babel/traverse': 7.18.10
+      '@babel/parser': 7.18.11
+      '@babel/traverse': 7.18.11
       '@babel/types': 7.18.10
       '@graphql-tools/utils': 8.9.0_graphql@16.5.0
       graphql: 16.5.0
@@ -3326,8 +3326,8 @@ packages:
     engines: {node: '>=12.0.0'}
     dev: false
 
-  /@peculiar/asn1-schema/2.2.0:
-    resolution: {integrity: sha512-1ENEJNY7Lwlua/1wvzpYP194WtjQBfFxvde2FlzfBFh/ln6wvChrtxlORhbKEnYswzn6fOC4c7HdC5izLPMTJg==}
+  /@peculiar/asn1-schema/2.3.0:
+    resolution: {integrity: sha512-DtNLAG4vmDrdSJFPe7rypkcj597chNQL7u+2dBtYo5mh7VW2+im6ke+O0NVr8W1f4re4C3F71LhoMb0Yxqa48Q==}
     dependencies:
       asn1js: 3.0.5
       pvtsutils: 1.3.2
@@ -3345,7 +3345,7 @@ packages:
     resolution: {integrity: sha512-U58N44b2m3OuTgpmKgf0LPDOmP3bhwNz01vAnj1mBwxBASRhptWYK+M3zG+HBkDqGQM+bFsoIihTW8MdmPXEqg==}
     engines: {node: '>=10.12.0'}
     dependencies:
-      '@peculiar/asn1-schema': 2.2.0
+      '@peculiar/asn1-schema': 2.3.0
       '@peculiar/json-schema': 1.1.12
       pvtsutils: 1.3.2
       tslib: 2.4.0
@@ -3762,7 +3762,7 @@ packages:
       form-data-encoder: 1.7.2
       formdata-node: 4.3.3
       node-fetch: 2.6.7
-      undici: 5.8.0
+      undici: 5.8.1
       web-streams-polyfill: 3.2.1
     transitivePeerDependencies:
       - encoding
@@ -4165,8 +4165,8 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
     dependencies:
-      caniuse-lite: 1.0.30001373
-      electron-to-chromium: 1.4.210
+      caniuse-lite: 1.0.30001374
+      electron-to-chromium: 1.4.211
       node-releases: 2.0.6
       update-browserslist-db: 1.0.5_browserslist@4.21.3
     dev: true
@@ -4263,8 +4263,8 @@ packages:
     resolution: {integrity: sha512-JToIvOmz6nhGsUhAYScbo2d6Py5wojjNfoxoc2mEVLUdJ70gJK2gnd+ABY1Tc3sVMyK7QDPtN0T/XdlCQWITyQ==}
     engines: {node: '>=14.16'}
 
-  /caniuse-lite/1.0.30001373:
-    resolution: {integrity: sha512-pJYArGHrPp3TUqQzFYRmP/lwJlj8RCbVe3Gd3eJQkAV8SAC6b19XS9BjMvRdvaS8RMkaTN8ZhoHP6S1y8zzwEQ==}
+  /caniuse-lite/1.0.30001374:
+    resolution: {integrity: sha512-mWvzatRx3w+j5wx/mpFN5v5twlPrabG8NqX2c6e45LCpymdoGqNvRkRutFUqpRTXKFQFNQJasvK0YT7suW6/Hw==}
     dev: true
 
   /capital-case/1.0.4:
@@ -4870,8 +4870,8 @@ packages:
       jake: 10.8.5
     dev: false
 
-  /electron-to-chromium/1.4.210:
-    resolution: {integrity: sha512-kSiX4tuyZijV7Cz0MWVmGT8K2siqaOA4Z66K5dCttPPRh0HicOcOAEj1KlC8O8J1aOS/1M8rGofOzksLKaHWcQ==}
+  /electron-to-chromium/1.4.211:
+    resolution: {integrity: sha512-BZSbMpyFQU0KBJ1JG26XGeFI3i4op+qOYGxftmZXFZoHkhLgsSv4DHDJfl8ogII3hIuzGt51PaZ195OVu0yJ9A==}
     dev: true
 
   /emoji-regex/8.0.0:
@@ -5277,7 +5277,7 @@ packages:
       eslint-import-resolver-node: 0.3.6
       eslint-module-utils: 2.7.3_gjpiwexkhexdr4bbgrtzf23bg4
       has: 1.0.3
-      is-core-module: 2.9.0
+      is-core-module: 2.10.0
       is-glob: 4.0.3
       minimatch: 3.1.2
       object.values: 1.1.5
@@ -6268,6 +6268,12 @@ packages:
     dependencies:
       ci-info: 3.3.2
     dev: false
+
+  /is-core-module/2.10.0:
+    resolution: {integrity: sha512-Erxj2n/LDAZ7H8WNJXd9tw38GYM3dv8rk8Zcs+jJuxYTW7sozH+SS8NtrSjVL1/vpLvWi1hxy96IzjJ3EHTJJg==}
+    dependencies:
+      has: 1.0.3
+    dev: true
 
   /is-core-module/2.9.0:
     resolution: {integrity: sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==}
@@ -7733,7 +7739,7 @@ packages:
     resolution: {integrity: sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==}
     hasBin: true
     dependencies:
-      is-core-module: 2.9.0
+      is-core-module: 2.10.0
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
     dev: true
@@ -7742,7 +7748,7 @@ packages:
     resolution: {integrity: sha512-iMDbmAWtfU+MHpxt/I5iWI7cY6YVEZUQ3MBgPQ++XD1PELuJHIl82xBmObyP2KyQmkNB2dsqF7seoQQiAn5yDQ==}
     hasBin: true
     dependencies:
-      is-core-module: 2.9.0
+      is-core-module: 2.10.0
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
     dev: true
@@ -8365,8 +8371,8 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /undici/5.8.0:
-    resolution: {integrity: sha512-1F7Vtcez5w/LwH2G2tGnFIihuWUlc58YidwLiCv+jR2Z50x0tNXpRRw7eOIJ+GvqCqIkg9SB7NWAJ/T9TLfv8Q==}
+  /undici/5.8.1:
+    resolution: {integrity: sha512-iDRmWX4Zar/4A/t+1LrKQRm102zw2l9Wgat3LtTlTn8ykvMZmAmpq9tjyHEigx18FsY7IfATvyN3xSw9BDz0eA==}
     engines: {node: '>=12.18'}
     dev: true
 
@@ -8497,7 +8503,7 @@ packages:
   /webcrypto-core/1.7.5:
     resolution: {integrity: sha512-gaExY2/3EHQlRNNNVSrbG2Cg94Rutl7fAaKILS1w8ZDhGxdFOaw6EbCfHIxPy9vt/xwp5o0VQAx9aySPF6hU1A==}
     dependencies:
-      '@peculiar/asn1-schema': 2.2.0
+      '@peculiar/asn1-schema': 2.3.0
       '@peculiar/json-schema': 1.1.12
       asn1js: 3.0.5
       pvtsutils: 1.3.2
@@ -8674,8 +8680,8 @@ packages:
     resolution: {integrity: sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==}
     engines: {node: '>=10'}
 
-  /yargs-parser/21.0.1:
-    resolution: {integrity: sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==}
+  /yargs-parser/21.1.0:
+    resolution: {integrity: sha512-xzm2t63xTV/f7+bGMSRzLhUNk1ajv/tDoaD5OeGyC3cFo2fl7My9Z4hS3q2VdQ7JaLvTxErO8Jp5pRIFGMD/zg==}
     engines: {node: '>=12'}
 
   /yargs/15.4.1:
@@ -8717,7 +8723,7 @@ packages:
       require-directory: 2.1.1
       string-width: 4.2.3
       y18n: 5.0.8
-      yargs-parser: 21.0.1
+      yargs-parser: 21.1.0
 
   /yn/3.1.1:
     resolution: {integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==}

--- a/src/cli/app/deploy.ts
+++ b/src/cli/app/deploy.ts
@@ -97,27 +97,29 @@ export const handler = async (argv: Arguments<Options>) => {
     await vercel.verifyDeployment(name, deploymentId);
   }
 
+  const domain = await vercel.getProjectDomain(projectId);
+
+  const projectManifestURL = `https://${domain.name}/api/manifest`;
+
   const msg1 = `     ${chalk.dim('Using the CLI')}: ${chalk.green(
     'saleor app install'
-  )}`;
+  )} and pass the following domain ${chalk.yellow(
+    projectManifestURL
+  )} as Manifest URL`;
   const msg2 = `${chalk.dim(
     'Using Dashboard UI'
   )}: open the following URL in the browser
 ${chalk.blue(
   envs.NEXT_PUBLIC_SALEOR_HOST_URL
 )}/dashboard/apps/install?manifestUrl=${chalk.yellow(
-    encodeURIComponent(`https://${deployment.url}/api/manifest`)
+    encodeURIComponent(projectManifestURL)
   )}`;
 
-  console.log(
-    boxen(`${msg1}\n${msg2}`, {
-      padding: 1,
-      margin: 0,
-      borderColor: 'blue',
-      borderStyle: 'round',
-      title: 'Next step: install this app in the Saleor Dashboard',
-    })
-  );
+  console.log(chalk.blue('─').repeat(process.stdout.columns));
+  console.log('');
+  console.log(` ${msg1}\n\n ${msg2}`);
+  console.log('');
+  console.log(chalk.blue('─').repeat(process.stdout.columns));
 
   process.exit(0);
 };
@@ -319,20 +321,15 @@ const displayURLs = (spinner: Ora, deployment: Deployment) => {
   spinner.succeed('App successfully queued for deployment');
   console.log('');
 
-  const msg1 = `         ${chalk.dim('App URL')}: ${chalk.blue(
-    `https://${deployment.url}`
-  )} `;
-  const msg2 = `${chalk.dim('Manifest App URL')}: ${chalk.blue(
-    `https://${deployment.url}/api/manifest`
-  )} `;
+  const msg1 = chalk.blue(`https://${deployment.url}`);
 
   console.log(
-    boxen(`${msg1} \n${msg2}`, {
+    boxen(msg1, {
       padding: 1,
       margin: 0,
       borderColor: 'blue',
       borderStyle: 'round',
-      title: 'Deployment URLs',
+      title: 'Deployment URL',
     })
   );
   console.log('');

--- a/src/lib/vercel.ts
+++ b/src/lib/vercel.ts
@@ -167,6 +167,16 @@ export class Vercel {
 
     return this._client('GET', `/v1/integrations/detect-framework?url=${URL}`);
   }
+
+  async getProjectDomains(projectID: string) {
+    return this._client('GET', `/v9/projects/${projectID}/domains`);
+  }
+
+  async getProjectDomain(projectID: string) {
+    const { domains } = await this.getProjectDomains(projectID);
+
+    return domains[0];
+  }
 }
 
 const hasDeploymentSucceeded = (readyState: string) => readyState !== 'READY';


### PR DESCRIPTION
The app installation must accept the project domain as the Manifest URL and not the deployment, e.g. you may want to `git push` during development and the Saleor dashboard should reference the newest deployment, thus using the project domain.

This PR also fixes how URLs for Next Steps are displayed; fixes #250