### PR TITLE
Change package name to target @saleor org

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,4 @@ test.js
 dummy/
 ..bfg-report
 .idea/
+.DS_Store

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "vitest": "^0.21.1"
   },
   "dependencies": {
+    "@saleor/cli": "latest",
     "@mobily/ts-belt": "^3.13.1",
     "@oclif/core": "^1.13.8",
     "@sentry/node": "^7.9.0",


### PR DESCRIPTION
CLI is meant to work as `@saleor/cli` in Saleor org in npm.

Before it's changed, simple proxy must be delivered to make `saleor` and `saler-cli` compatible

#271 