### PR TITLE
Move no-warnings flag to env var

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env node --no-warnings
+#!/usr/bin/env NODE_OPTIONS=--no-warnings node
 
 import * as Sentry from '@sentry/node';
 import chalk from 'chalk';


### PR DESCRIPTION
* For broader runtime environment compatibility. Seems some environments
  doesn't split the argument string which may be the cause of `No such
  file or directory` error