### PR TITLE
Display active local port that is tunnelling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,4 @@ test.js
 dummy/
 ..bfg-report
 .idea/
+.DS_Store

--- a/src/cli/app/tunnel.ts
+++ b/src/cli/app/tunnel.ts
@@ -147,6 +147,11 @@ export const handler = async (argv: Arguments<Options>): Promise<void> => {
     } = apps.filter(byName(appName)).shift();
 
     console.log(
+      `Tunnel is listening to you local machine on port: ${chalk.blue(
+        localPort
+      )}\n`
+    );
+    console.log(
       'Press CTRL-C to stop the tunnel and uninstall this Saleor App...'
     );
     // eslint-disable-next-line no-constant-condition

--- a/src/cli/app/tunnel.ts
+++ b/src/cli/app/tunnel.ts
@@ -147,7 +147,7 @@ export const handler = async (argv: Arguments<Options>): Promise<void> => {
     } = apps.filter(byName(appName)).shift();
 
     console.log(
-      `Tunnel is listening to you local machine on port: ${chalk.blue(
+      `Tunnel is listening to your local machine on port: ${chalk.blue(
         localPort
       )}\n`
     );


### PR DESCRIPTION
I'd like to have this feature, because as a new user I wasn't aware it always looks for `:3000`

My app was running on `3001` and I didn't know there was some detached process on `:3000` causing a bug.