### PR TITLE
Add `app attach` command

### DIFF
--- a/src/cli/app/attach.ts
+++ b/src/cli/app/attach.ts
@@ -1,0 +1,50 @@
+import dotenv from 'dotenv';
+import fs from 'fs-extra';
+import path from 'path';
+import { Arguments, CommandBuilder } from 'yargs';
+
+import { getEnvironment } from '../../lib/environment.js';
+import {
+  useEnvironment,
+  useOrganization,
+  useToken,
+} from '../../middleware/index.js';
+import { AppAttachOptions } from '../../types.js';
+
+export const command = 'attach';
+export const desc = 'Attach a Saleor App to the Saleor environment';
+
+export const builder: CommandBuilder = (_) =>
+  _.option('name', {
+    type: 'string',
+    default: 'NEXT_PUBLIC_SALEOR_HOST_URL',
+    desc: 'Environment variable name',
+  }).option('value', {
+    type: 'string',
+    desc: 'Environment variable value',
+  });
+
+export const handler = async (argv: Arguments<AppAttachOptions>) => {
+  const { name, value } = argv;
+
+  const { domain } = await getEnvironment(argv);
+  const endpoint = `https://${domain}`;
+
+  let file;
+  try {
+    file = await fs.readFile(path.join(process.cwd(), '.env'));
+  } catch {
+    file = '';
+  }
+  const envs = dotenv.parse(file);
+  envs[name] = value || endpoint;
+
+  await fs.writeFile(
+    path.join(process.cwd(), '.env'),
+    Object.entries(envs)
+      .map(([key, _value]) => `${key}=${_value}`)
+      .join('\n')
+  );
+};
+
+export const middlewares = [useToken, useOrganization, useEnvironment];

--- a/src/cli/app/index.ts
+++ b/src/cli/app/index.ts
@@ -1,3 +1,4 @@
+import * as attach from './attach.js';
 import * as create from './create.js';
 import * as deploy from './deploy.js';
 import * as generate from './generate.js';
@@ -9,13 +10,14 @@ import * as tunnel from './tunnel.js';
 
 export default function (_: any) {
   _.command([
+    attach,
+    create,
+    deploy,
     list,
     install,
-    create,
-    tunnel,
-    token,
     permission,
-    deploy,
+    token,
+    tunnel,
 
     // no auth needed
     generate,

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,6 +31,11 @@ export interface Options extends BaseOptions {
   registerUrl?: string;
 }
 
+export interface AppAttachOptions extends BaseOptions {
+  name: string;
+  value?: string;
+}
+
 export interface CreatePromptResult {
   name: string;
   value: string | number;


### PR DESCRIPTION
**I want to merge this PR because: ***
* it allows to create or update `.env` file with saleor endpoint


## Related issues

- https://github.com/saleor/saleor-cli/issues/310

## Steps to test feature

- run `saleor app attach`
- the `.env` file should be created or updated with NEXT_PUBLIC_SALEOR_HOST_URL env var

## I have:

- [x] Tested it locally and it doesn't break existing features
- [ ] Added documentation if public changes are introduced
- [ ] Added tests for my code