### PR TITLE
Remove `.env` file requirement for `app` commands

### DIFF
--- a/src/lib/common.ts
+++ b/src/lib/common.ts
@@ -142,13 +142,12 @@ export const verifyIsSaleorAppDirectory = async (argv: any) => {
   // check if this is a Next.js app
   const isNodeApp = await fs.pathExists('package.json');
   const isNextApp = await fs.pathExists('next.config.js');
-  const hasDotEnvFile = await fs.pathExists('.env');
 
   if (!isTunnel) {
     return {};
   }
 
-  if (!isNextApp || !isNodeApp || !hasDotEnvFile) {
+  if (!isNextApp || !isNodeApp) {
     throw new NotSaleorAppDirectoryError(
       `'app ${argv._[1]}' must be run from the directory of your Saleor app`
     );

--- a/src/lib/vercel.ts
+++ b/src/lib/vercel.ts
@@ -4,7 +4,7 @@ import ora from 'ora';
 
 import { delay } from './util.js';
 
-interface Env {
+export interface Env {
   key: string;
   value: string;
   target?: string[];


### PR DESCRIPTION
**I want to merge this PR because: ***

It removes the `.env` file requirement for `app create` and `app deploy` commands. No environment variables from the `.env` file are required for the aforementioned commands.

In the same time the `app create` doesn't require 


## Related issues

- 

## Steps to test feature

- create an app `saleor app create` - in the created folder there should be no `.env` file, and there should be no prompt for the organization and the environment
- deploy an app `saleor app deploy` - the `.env` file should not be required to deploy an app

## I have:

- [x] Tested it locally and it doesn't break existing features
- [ ] Added documentation if public changes are introduced
- [ ] Added tests for my code