### PR TITLE
Add `debug` to all commands

### DIFF
--- a/src/cli/app/create.ts
+++ b/src/cli/app/create.ts
@@ -16,7 +16,7 @@ import { checkPnpmPresence } from '../../lib/util.js';
 import { useToken } from '../../middleware/index.js';
 import { StoreCreate } from '../../types.js';
 
-const debug = Debug('app:create');
+const debug = Debug('saleor-cli:app:create');
 
 export const command = 'create [name]';
 export const desc = 'Create a Saleor App template';
@@ -33,6 +33,8 @@ export const builder: CommandBuilder = (_) =>
   });
 
 export const handler = async (argv: Arguments<StoreCreate>): Promise<void> => {
+  debug(`command arguments: ${JSON.stringify(argv, null, 2)}`);
+
   debug('check PNPM presence');
   await checkPnpmPresence('This Saleor App template');
 

--- a/src/cli/app/deploy.ts
+++ b/src/cli/app/deploy.ts
@@ -24,7 +24,7 @@ import {
 } from '../../middleware/index.js';
 import { Options } from '../../types.js';
 
-const debug = Debug('app:deploy');
+const debug = Debug('saleor-cli:app:deploy');
 
 export const command = 'deploy';
 export const desc = 'Deploy this Saleor App repository to Vercel';
@@ -50,6 +50,8 @@ export const builder: CommandBuilder = (_) =>
     });
 
 export const handler = async (argv: Arguments<Options>) => {
+  debug(`command arguments: ${JSON.stringify(argv, null, 2)}`);
+
   debug('extracting the `name` from `package.json` of this Saleor App');
   const { name } = JSON.parse(
     await fs.readFile(path.join(process.cwd(), 'package.json'), 'utf-8')

--- a/src/cli/app/generate.ts
+++ b/src/cli/app/generate.ts
@@ -17,7 +17,7 @@ import { Options } from '../../types.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
-const debug = Debug('app:generate');
+const debug = Debug('saleor-cli:app:generate');
 
 export const command = 'generate <resource>';
 export const desc = 'Generate a resource for a Saleor App';
@@ -30,6 +30,8 @@ export const builder: CommandBuilder = (_) =>
   });
 
 export const handler = async (argv: Arguments<Options>) => {
+  debug(`command arguments: ${JSON.stringify(argv, null, 2)}`);
+
   const { resource } = argv;
 
   switch (resource) {

--- a/src/cli/app/install.ts
+++ b/src/cli/app/install.ts
@@ -10,7 +10,7 @@ import {
 } from '../../middleware/index.js';
 import { Options } from '../../types.js';
 
-const debug = Debug('app:install');
+const debug = Debug('saleor-cli:app:install');
 
 export const command = 'install';
 export const desc = 'Install a Saleor App by URL';
@@ -22,8 +22,9 @@ export const builder: CommandBuilder = (_) =>
   });
 
 export const handler = async (argv: Arguments<Options>) => {
+  debug(`command arguments: ${JSON.stringify(argv, null, 2)}`);
+
   const { organization, environment } = argv;
-  debug(`start with --via-dashboard=${argv.viaDashboard}`);
 
   printContext(organization, environment);
 

--- a/src/cli/app/list.ts
+++ b/src/cli/app/list.ts
@@ -21,12 +21,14 @@ import { Options } from '../../types.js';
 
 const { ux: cli } = CliUx;
 
-const debug = Debug('app:list');
+const debug = Debug('saleor-cli:app:list');
 
 export const command = 'list';
 export const desc = 'List installed Saleor Apps for an environment';
 
 export const handler = async (argv: Arguments<Options>) => {
+  debug(`command arguments: ${JSON.stringify(argv, null, 2)}`);
+
   const { organization, environment } = argv;
 
   printContext(organization, environment);

--- a/src/cli/app/permission.ts
+++ b/src/cli/app/permission.ts
@@ -17,12 +17,14 @@ import {
 } from '../../middleware/index.js';
 import { Options } from '../../types.js';
 
-const debug = Debug('app:permission');
+const debug = Debug('saleor-cli:app:permission');
 
 export const command = 'permission';
 export const desc = 'Add or remove permission for a Saleor App';
 
 export const handler = async (argv: Arguments<Options>) => {
+  debug(`command arguments: ${JSON.stringify(argv, null, 2)}`);
+
   const { organization, environment } = argv;
 
   printContext(organization, environment);

--- a/src/cli/app/token.ts
+++ b/src/cli/app/token.ts
@@ -17,12 +17,14 @@ import {
 } from '../../middleware/index.js';
 import { Options } from '../../types.js';
 
-const debug = Debug('app:token');
+const debug = Debug('saleor-cli:app:token');
 
 export const command = 'token';
 export const desc = 'Create a Saleor App token';
 
 export const handler = async (argv: Arguments<Options>) => {
+  debug(`command arguments: ${JSON.stringify(argv, null, 2)}`);
+
   const { organization, environment } = argv;
 
   printContext(organization, environment);

--- a/src/cli/app/tunnel.ts
+++ b/src/cli/app/tunnel.ts
@@ -42,7 +42,7 @@ async function getKeypress() {
   });
 }
 
-const debug = Debug('app:tunnel');
+const debug = Debug('saleor-cli:app:tunnel');
 
 export const command = 'tunnel [port]';
 export const desc = 'Expose your Saleor app remotely via tunnel';
@@ -53,6 +53,8 @@ export const builder: CommandBuilder = (_) =>
   });
 
 export const handler = async (argv: Arguments<Options>): Promise<void> => {
+  debug(`command arguments: ${JSON.stringify(argv, null, 2)}`);
+
   debug(`Starting the tunnel with the port: ${argv.port}`);
   const __dirname = path.dirname(fileURLToPath(import.meta.url));
   const vendorDir = path.join(__dirname, '..', '..', '..', 'vendor');

--- a/src/cli/backup/create.ts
+++ b/src/cli/backup/create.ts
@@ -4,7 +4,7 @@ import type { Arguments, CommandBuilder } from 'yargs';
 import { API, POST } from '../../lib/index.js';
 import { showResult, waitForTask } from '../../lib/util.js';
 
-const debug = Debug('backup:create');
+const debug = Debug('saleor-cli:backup:create');
 
 export const command = 'create <name>';
 export const desc = 'Create a new backup';
@@ -17,6 +17,8 @@ export const builder: CommandBuilder = (_) =>
   });
 
 export const handler = async (argv: Arguments<any>) => {
+  debug(`command arguments: ${JSON.stringify(argv, null, 2)}`);
+
   const { name } = argv;
 
   debug(`Using the name: ${name}`);

--- a/src/cli/backup/list.ts
+++ b/src/cli/backup/list.ts
@@ -9,12 +9,14 @@ import { Options } from '../../types.js';
 
 const { ux: cli } = CliUx;
 
-const debug = Debug('backup:list');
+const debug = Debug('saleor-cli:backup:list');
 
 export const command = 'list [key|environment]';
 export const desc = 'List backups of the environment';
 
 export const handler = async (argv: Arguments<Options>) => {
+  debug(`command arguments: ${JSON.stringify(argv, null, 2)}`);
+
   debug(`Listing for ${argv.key}`);
   const result = (await GET(API.Backup, argv)) as any[];
 

--- a/src/cli/backup/restore.ts
+++ b/src/cli/backup/restore.ts
@@ -8,7 +8,7 @@ import { promptOrganizationBackup, waitForTask } from '../../lib/util.js';
 import { Options } from '../../types.js';
 import { updateWebhook } from '../webhook/update.js';
 
-const debug = Debug('backup:restore');
+const debug = Debug('saleor-cli:backup:restore');
 
 export const command = 'restore [from]';
 export const desc = 'Restore a specific backup';
@@ -25,9 +25,7 @@ export const builder: CommandBuilder = (_) =>
   });
 
 export const handler = async (argv: Arguments<Options>) => {
-  debug(
-    `Started with --from=${argv.from} and --skip-webhooks-update=${argv.skipWebhooksUpdate}`
-  );
+  debug(`command arguments: ${JSON.stringify(argv, null, 2)}`);
 
   const from = await getBackup(argv);
 

--- a/src/cli/backup/show.ts
+++ b/src/cli/backup/show.ts
@@ -1,8 +1,11 @@
+import Debug from 'debug';
 import type { Arguments, CommandBuilder } from 'yargs';
 
 import { API, GET, NoCommandBuilderSetup } from '../../lib/index.js';
 import { showResult } from '../../lib/util.js';
 import { Options } from '../../types.js';
+
+const debug = Debug('saleor-cli:backup:show');
 
 export const command = 'show [backup]';
 export const desc = 'Show a specific backup';
@@ -10,6 +13,8 @@ export const desc = 'Show a specific backup';
 export const builder: CommandBuilder = NoCommandBuilderSetup;
 
 export const handler = async (argv: Arguments<Options>) => {
+  debug(`command arguments: ${JSON.stringify(argv, null, 2)}`);
+
   const result = (await GET(API.Backup, argv)) as any;
   showResult(result, argv);
 };

--- a/src/cli/checkout/deploy.ts
+++ b/src/cli/checkout/deploy.ts
@@ -17,7 +17,7 @@ import { Vercel } from '../../lib/vercel.js';
 import { Options } from '../../types.js';
 import { createAppToken } from '../app/token.js';
 
-const debug = Debug('checkout:deploy');
+const debug = Debug('saleor-cli:checkout:deploy');
 
 export const command = 'deploy [name]';
 export const desc = 'Deploy `saleor-checkout` to Vercel';
@@ -27,6 +27,8 @@ const nanoid = customAlphabet('1234567890abcdefghijklmnopqrstuvwxyz', 10);
 export const builder: CommandBuilder = NoCommandBuilderSetup;
 
 export const handler = async (argv: Arguments<Options & { name: string }>) => {
+  debug(`command arguments: ${JSON.stringify(argv, null, 2)}`);
+
   const name = argv.name || `saleor-checkout-${nanoid(8).toLocaleLowerCase()}`;
   debug(`Using the name: ${name}`);
   const { domain } = await getEnvironment(argv);

--- a/src/cli/configure.ts
+++ b/src/cli/configure.ts
@@ -1,5 +1,6 @@
 import { CliUx } from '@oclif/core';
 import chalk from 'chalk';
+import Debug from 'debug';
 import Enquirer from 'enquirer';
 import type { Arguments, CommandBuilder } from 'yargs';
 
@@ -9,6 +10,8 @@ import { promptEnvironment, promptOrganization } from '../lib/util.js';
 import { Options } from '../types.js';
 
 const { ux: cli } = CliUx;
+
+const debug = Debug('saleor-cli:configure');
 
 export const command = 'configure [token]';
 export const desc = 'Configure Saleor CLI';
@@ -23,6 +26,8 @@ export const builder: CommandBuilder = (_) =>
   );
 
 export const handler = async (argv: Arguments<Options>) => {
+  debug(`command arguments: ${JSON.stringify(argv, null, 2)}`);
+
   const { token, force } = argv;
   const legitToken = await configure(token);
 

--- a/src/cli/dev/prepare.ts
+++ b/src/cli/dev/prepare.ts
@@ -1,4 +1,5 @@
 import chalk from 'chalk';
+import Debug from 'debug';
 import got from 'got';
 import { simpleGit } from 'simple-git';
 import { Arguments } from 'yargs';
@@ -11,13 +12,18 @@ interface Options {
   branch?: string;
 }
 
+const debug = Debug('saleor-cli:dev:prepare');
+
 export const command = 'prepare [branch|prURL]';
 export const desc = 'Build cli from branch or pull request URL';
 
 export const handler = async (argv: Arguments<Options>) => {
+  debug(`command arguments: ${JSON.stringify(argv, null, 2)}`);
+
   const git = simpleGit();
 
   // check if repo is saleor-cli
+  debug('check if `prepare` is run from the `saleor-cli` repository');
   try {
     const repo = (await git.remote(['get-url', 'origin'])) as string;
     const repoName = repo.trim().split('/').at(-1);
@@ -79,6 +85,7 @@ export const handler = async (argv: Arguments<Options>) => {
       };
     }
 
+    debug('Get the SHA of the PR using GitHub GraphQL API');
     const { data } = await got
       .post('https://api.github.com/graphql', {
         headers: { Authorization: GitHubToken },

--- a/src/cli/env/clear.ts
+++ b/src/cli/env/clear.ts
@@ -1,8 +1,11 @@
+import Debug from 'debug';
 import type { Arguments, CommandBuilder } from 'yargs';
 
 import { API, GET } from '../../lib/index.js';
 import { waitForTask } from '../../lib/util.js';
 import { Options } from '../../types.js';
+
+const debug = Debug('saleor-cli:env:clear');
 
 export const command = 'clear <key|environment>';
 export const desc = 'Clear database for environment';
@@ -15,6 +18,8 @@ export const builder: CommandBuilder = (_) =>
   });
 
 export const handler = async (argv: Arguments<Options>) => {
+  debug(`command arguments: ${JSON.stringify(argv, null, 2)}`);
+  debug('sending the request to Saleor API');
   const result = (await GET(API.ClearDatabase, argv)) as any;
   await waitForTask(argv, result.task_id, 'Clearing', 'Yay! Database cleared!');
 };

--- a/src/cli/env/list.ts
+++ b/src/cli/env/list.ts
@@ -1,11 +1,14 @@
 import { CliUx } from '@oclif/core';
 import chalk from 'chalk';
+import Debug from 'debug';
 import { Arguments, CommandBuilder } from 'yargs';
 
 import { API, GET } from '../../lib/index.js';
 import { formatDateTime, verifyResultLength } from '../../lib/util.js';
 
 const { ux: cli } = CliUx;
+
+const debug = Debug('saleor-cli:env:list');
 
 export const command = 'list';
 export const desc = 'List environments';
@@ -18,6 +21,8 @@ export const builder: CommandBuilder = (_) =>
   });
 
 export const handler = async (argv: Arguments) => {
+  debug(`command arguments: ${JSON.stringify(argv, null, 2)}`);
+
   const { extended } = argv;
   const result = (await GET(API.Environment, {
     ...argv,

--- a/src/cli/env/populate.ts
+++ b/src/cli/env/populate.ts
@@ -1,8 +1,11 @@
+import Debug from 'debug';
 import type { Arguments, CommandBuilder } from 'yargs';
 
 import { API, GET } from '../../lib/index.js';
 import { waitForTask } from '../../lib/util.js';
 import { Options } from '../../types.js';
+
+const debug = Debug('saleor-cli:env:populate');
 
 export const command = 'populate <key|environment>';
 export const desc = 'Populate database for environment';
@@ -15,6 +18,8 @@ export const builder: CommandBuilder = (_) =>
   });
 
 export const handler = async (argv: Arguments<Options>) => {
+  debug(`command arguments: ${JSON.stringify(argv, null, 2)}`);
+
   const result = (await GET(API.PopulateDatabase, argv)) as any;
   await waitForTask(
     argv,

--- a/src/cli/env/promote.ts
+++ b/src/cli/env/promote.ts
@@ -1,3 +1,4 @@
+import Debug from 'debug';
 import type { Arguments, CommandBuilder } from 'yargs';
 
 import { getEnvironment } from '../../lib/environment.js';
@@ -5,6 +6,8 @@ import { API, PUT } from '../../lib/index.js';
 import { promptCompatibleVersion, showResult } from '../../lib/util.js';
 import { useEnvironment } from '../../middleware/index.js';
 import { Options } from '../../types.js';
+
+const debug = Debug('saleor-cli:env:promote');
 
 export const command = 'promote [key|environment]';
 export const desc = 'Promote environment to production';
@@ -20,6 +23,8 @@ export const builder: CommandBuilder = (_) =>
   });
 
 export const handler = async (argv: Arguments<Options>) => {
+  debug(`command arguments: ${JSON.stringify(argv, null, 2)}`);
+
   const service = await getService(argv);
   const result = (await PUT(API.UpgradeEnvironment, argv, {
     json: { service: service.value },

--- a/src/cli/env/remove.ts
+++ b/src/cli/env/remove.ts
@@ -1,4 +1,5 @@
 import chalk from 'chalk';
+import Debug from 'debug';
 import type { Arguments, CommandBuilder } from 'yargs';
 
 import { Config } from '../../lib/config.js';
@@ -6,6 +7,8 @@ import { API, DELETE, GET } from '../../lib/index.js';
 import { confirmRemoval, waitForTask } from '../../lib/util.js';
 import { useEnvironment } from '../../middleware/index.js';
 import { Options, Task } from '../../types.js';
+
+const debug = Debug('saleor-cli:env:remove');
 
 export const command = 'remove [key|environment]';
 export const desc = 'Delete an environment';
@@ -21,6 +24,8 @@ export const builder: CommandBuilder = (_) =>
   });
 
 export const handler = async (argv: Arguments<Options>) => {
+  debug(`command arguments: ${JSON.stringify(argv, null, 2)}`);
+
   const { environment } = argv;
 
   const proceed = await confirmRemoval(argv, `environment ${environment}`);

--- a/src/cli/env/show.ts
+++ b/src/cli/env/show.ts
@@ -1,9 +1,12 @@
+import Debug from 'debug';
 import type { Arguments, CommandBuilder } from 'yargs';
 
 import { getEnvironment } from '../../lib/environment.js';
 import { showResult } from '../../lib/util.js';
 import { useEnvironment } from '../../middleware/index.js';
 import { Options } from '../../types.js';
+
+const debug = Debug('saleor-cli:env:show');
 
 export const command = 'show [key|environment]';
 export const desc = 'Show a specific environment';
@@ -16,6 +19,8 @@ export const builder: CommandBuilder = (_) =>
   });
 
 export const handler = async (argv: Arguments<Options>) => {
+  debug(`command arguments: ${JSON.stringify(argv, null, 2)}`);
+
   const result = await getEnvironment(argv);
 
   showResult(result, argv);

--- a/src/cli/env/switch.ts
+++ b/src/cli/env/switch.ts
@@ -1,4 +1,5 @@
 import chalk from 'chalk';
+import Debug from 'debug';
 import type { Arguments, CommandBuilder } from 'yargs';
 
 import { Config } from '../../lib/config.js';
@@ -7,6 +8,8 @@ import { promptEnvironment } from '../../lib/util.js';
 type Options = {
   key?: string;
 };
+
+const debug = Debug('saleor-cli:env:switch');
 
 export const command = 'switch [key|environment]';
 export const desc = 'Make the provided environment the default one';
@@ -19,6 +22,8 @@ export const builder: CommandBuilder = (_) =>
   });
 
 export const handler = async (argv: Arguments<Options>) => {
+  debug(`command arguments: ${JSON.stringify(argv, null, 2)}`);
+
   const environment = await getEnvironment(argv);
 
   await Config.set('environment_id', environment.value);

--- a/src/cli/env/upgrade.ts
+++ b/src/cli/env/upgrade.ts
@@ -1,3 +1,4 @@
+import Debug from 'debug';
 import type { Arguments, CommandBuilder } from 'yargs';
 
 import { getEnvironment } from '../../lib/environment.js';
@@ -5,6 +6,8 @@ import { API, PUT } from '../../lib/index.js';
 import { promptCompatibleVersion, waitForTask } from '../../lib/util.js';
 import { useEnvironment } from '../../middleware/index.js';
 import { Options } from '../../types.js';
+
+const debug = Debug('saleor-cli:env:upgrade');
 
 export const command = 'upgrade [key|environment]';
 export const desc = 'Upgrade a Saleor version in a specific environment';
@@ -17,6 +20,8 @@ export const builder: CommandBuilder = (_) =>
   });
 
 export const handler = async (argv: Arguments<Options>) => {
+  debug(`command arguments: ${JSON.stringify(argv, null, 2)}`);
+
   const env = await getEnvironment(argv);
   const service = await promptCompatibleVersion({
     ...argv,

--- a/src/cli/github/login.ts
+++ b/src/cli/github/login.ts
@@ -1,4 +1,5 @@
 import { CliUx } from '@oclif/core';
+import Debug from 'debug';
 import detectPort from 'detect-port';
 import EventEmitter from 'events';
 import got from 'got';
@@ -12,6 +13,8 @@ import { Config } from '../../lib/config.js';
 import { delay } from '../../lib/util.js';
 
 const { ux: cli } = CliUx;
+
+const debug = Debug('saleor-cli:github:login');
 
 export const command = 'login';
 export const desc = 'Add integration for Saleor CLI';

--- a/src/cli/info.ts
+++ b/src/cli/info.ts
@@ -1,5 +1,6 @@
 import { CliUx } from '@oclif/core';
 import chalk from 'chalk';
+import Debug from 'debug';
 import figlet from 'figlet';
 import { createRequire } from 'module';
 import type { CommandBuilder } from 'yargs';
@@ -10,6 +11,9 @@ const require = createRequire(import.meta.url);
 const pkg = require('../../package.json');
 
 const { ux: cli } = CliUx;
+
+const debug = Debug('saleor-cli:info');
+
 export const command = 'info';
 export const desc = 'Hello from Saleor';
 

--- a/src/cli/job/list.ts
+++ b/src/cli/job/list.ts
@@ -1,5 +1,6 @@
 import { CliUx } from '@oclif/core';
 import chalk from 'chalk';
+import Debug from 'debug';
 import { Arguments, CommandBuilder } from 'yargs';
 
 import { API, GET } from '../../lib/index.js';
@@ -16,6 +17,8 @@ const parseJobName = (name: string) => {
 
 // TODO environment required in config or as param!!!!!!
 
+const debug = Debug('saleor-cli:job:list');
+
 export const command = 'list';
 export const desc = 'List jobs';
 
@@ -23,6 +26,7 @@ export const builder: CommandBuilder = (_) =>
   _.option('env', { type: 'string' });
 
 export const handler = async (argv: Arguments<Options>) => {
+  debug(`command arguments: ${JSON.stringify(argv, null, 2)}`);
   const result = (await GET(API.Job, argv)) as any[];
 
   cli.table(result, {

--- a/src/cli/logout.ts
+++ b/src/cli/logout.ts
@@ -1,12 +1,13 @@
-import type { CommandBuilder } from 'yargs';
+import Debug from 'debug';
 
 import { Config } from '../lib/config.js';
+
+const debug = Debug('saleor-cli:logout');
 
 export const command = 'logout';
 export const desc = 'Log out from the Saleor Cloud';
 
-export const builder: CommandBuilder = (_) => _;
-
 export const handler = (): void => {
+  debug('resetting the config at `~/.config/saleor.json`');
   Config.reset();
 };

--- a/src/cli/organization/list.ts
+++ b/src/cli/organization/list.ts
@@ -1,5 +1,6 @@
 import { CliUx } from '@oclif/core';
 import { format } from 'date-fns';
+import Debug from 'debug';
 import { Arguments } from 'yargs';
 
 import { API, GET } from '../../lib/index.js';
@@ -8,10 +9,14 @@ import { Options } from '../../types.js';
 
 const { ux: cli } = CliUx;
 
+const debug = Debug('saleor-cli:org:list');
+
 export const command = 'list';
 export const desc = 'List organizations';
 
 export const handler = async (argv: Arguments<Options>) => {
+  debug(`command arguments: ${JSON.stringify(argv, null, 2)}`);
+
   const result = (await GET(API.Organization, {
     ...argv,
     organization: '',

--- a/src/cli/organization/permissions.ts
+++ b/src/cli/organization/permissions.ts
@@ -1,9 +1,12 @@
+import Debug from 'debug';
 import type { Arguments, CommandBuilder } from 'yargs';
 
 import { API, GET } from '../../lib/index.js';
 import { showResult } from '../../lib/util.js';
 import { useOrganization } from '../../middleware/index.js';
 import { Options } from '../../types.js';
+
+const debug = Debug('saleor-cli:org:permissions');
 
 export const command = 'permissions [slug|organization]';
 export const desc = 'List organization permissions';
@@ -16,6 +19,8 @@ export const builder: CommandBuilder = (_) =>
   });
 
 export const handler = async (argv: Arguments<Options>) => {
+  debug(`command arguments: ${JSON.stringify(argv, null, 2)}`);
+
   const result = (await GET(API.OrganizationPermissions, {
     ...argv,
     ...{ organization: argv.slug || argv.organization },

--- a/src/cli/organization/remove.ts
+++ b/src/cli/organization/remove.ts
@@ -1,10 +1,13 @@
 import chalk from 'chalk';
+import Debug from 'debug';
 import type { Arguments, CommandBuilder } from 'yargs';
 
 import { Config } from '../../lib/config.js';
 import { API, DELETE } from '../../lib/index.js';
 import { confirmRemoval, promptOrganization } from '../../lib/util.js';
 import { Options } from '../../types.js';
+
+const debug = Debug('saleor-cli:org:remove');
 
 export const command = 'remove [slug]';
 export const desc = 'Remove the organization';
@@ -20,6 +23,7 @@ export const builder: CommandBuilder = (_) =>
   });
 
 export const handler = async (argv: Arguments<Options>) => {
+  debug(`command arguments: ${JSON.stringify(argv, null, 2)}`);
   const organization = argv.slug
     ? { name: argv.slug, value: argv.slug }
     : await promptOrganization(argv);

--- a/src/cli/organization/show.ts
+++ b/src/cli/organization/show.ts
@@ -1,3 +1,4 @@
+import Debug from 'debug';
 import type { Arguments, CommandBuilder } from 'yargs';
 
 import { API, GET } from '../../lib/index.js';
@@ -5,12 +6,15 @@ import { showResult } from '../../lib/util.js';
 import { useOrganization } from '../../middleware/index.js';
 import { Options } from '../../types.js';
 
+const debug = Debug('saleor-cli:org:show');
+
 export const command = 'show [slug|organization]';
 export const desc = 'Show a specific organization';
 
 export const builder: CommandBuilder = (_) => _;
 
 export const handler = async (argv: Arguments<Options>) => {
+  debug(`command arguments: ${JSON.stringify(argv, null, 2)}`);
   const result = (await GET(API.Organization, argv)) as any;
 
   showResult(result, argv);

--- a/src/cli/organization/switch.ts
+++ b/src/cli/organization/switch.ts
@@ -1,10 +1,13 @@
 import chalk from 'chalk';
+import Debug from 'debug';
 import type { Arguments, CommandBuilder } from 'yargs';
 
 import { Config } from '../../lib/config.js';
 import { API, GET } from '../../lib/index.js';
 import { promptOrganization } from '../../lib/util.js';
 import { Options } from '../../types.js';
+
+const debug = Debug('saleor-cli:org:switch');
 
 export const command = 'switch [slug]';
 export const desc = 'Make the provided organization the default one';
@@ -17,6 +20,7 @@ export const builder: CommandBuilder = (_) =>
   });
 
 export const handler = async (argv: Arguments<Options>) => {
+  debug(`command arguments: ${JSON.stringify(argv, null, 2)}`);
   const organization = await getOrganization(argv);
 
   await Config.set('organization_slug', organization.value);

--- a/src/cli/project/create.ts
+++ b/src/cli/project/create.ts
@@ -1,7 +1,10 @@
+import Debug from 'debug';
 import type { Arguments, CommandBuilder } from 'yargs';
 
 import { createProject } from '../../lib/util.js';
 import { ProjectCreate } from '../../types.js';
+
+const debug = Debug('saleor-cli:project:create');
 
 export const command = 'create [name]';
 export const desc = 'Create a new project';
@@ -22,5 +25,6 @@ export const builder: CommandBuilder = (_) =>
     });
 
 export const handler = async (argv: Arguments<ProjectCreate>) => {
+  debug(`command arguments: ${JSON.stringify(argv, null, 2)}`);
   await createProject(argv);
 };

--- a/src/cli/project/list.ts
+++ b/src/cli/project/list.ts
@@ -1,5 +1,6 @@
 import { CliUx } from '@oclif/core';
 import chalk from 'chalk';
+import Debug from 'debug';
 import { Arguments } from 'yargs';
 
 import { API, GET } from '../../lib/index.js';
@@ -8,10 +9,13 @@ import { Options } from '../../types.js';
 
 const { ux: cli } = CliUx;
 
+const debug = Debug('saleor-cli:project:list');
+
 export const command = 'list';
 export const desc = 'List projects';
 
 export const handler = async (argv: Arguments<Options>) => {
+  debug(`command arguments: ${JSON.stringify(argv, null, 2)}`);
   const result = (await GET(API.Project, argv)) as any[];
 
   cli.table(result, {

--- a/src/cli/project/remove.ts
+++ b/src/cli/project/remove.ts
@@ -1,9 +1,12 @@
 import chalk from 'chalk';
+import Debug from 'debug';
 import type { Arguments, CommandBuilder } from 'yargs';
 
 import { API, DELETE } from '../../lib/index.js';
 import { confirmRemoval, promptProject } from '../../lib/util.js';
 import { Options } from '../../types.js';
+
+const debug = Debug('saleor-cli:project:remove');
 
 export const command = 'remove [slug]';
 export const desc = 'Remove the project';
@@ -19,6 +22,7 @@ export const builder: CommandBuilder = (_) =>
   });
 
 export const handler = async (argv: Arguments<Options>) => {
+  debug(`command arguments: ${JSON.stringify(argv, null, 2)}`);
   const project = argv.slug
     ? { name: argv.slug, value: argv.slug }
     : await promptProject(argv);

--- a/src/cli/project/show.ts
+++ b/src/cli/project/show.ts
@@ -1,9 +1,12 @@
+import Debug from 'debug';
 import type { Arguments, CommandBuilder } from 'yargs';
 
 import { API, GET } from '../../lib/index.js';
 import { showResult } from '../../lib/util.js';
 import { interactiveProject } from '../../middleware/index.js';
 import { Options } from '../../types.js';
+
+const debug = Debug('saleor-cli:project:show');
 
 export const command = 'show [project]';
 export const desc = 'Show a specific project';
@@ -12,6 +15,7 @@ export const builder: CommandBuilder = (_) =>
   _.positional('project', { type: 'string', demandOption: false });
 
 export const handler = async (argv: Arguments<Options>) => {
+  debug(`command arguments: ${JSON.stringify(argv, null, 2)}`);
   const result = (await GET(API.Project, argv)) as any;
   showResult(result, argv);
 };

--- a/src/cli/register.ts
+++ b/src/cli/register.ts
@@ -1,6 +1,7 @@
 import { CliUx } from '@oclif/core';
 import { Amplify, Auth } from 'aws-amplify';
 import chalk from 'chalk';
+import Debug from 'debug';
 import Enquirer from 'enquirer';
 import { Arguments, CommandBuilder } from 'yargs';
 
@@ -9,6 +10,8 @@ import { validateEmail } from '../lib/util.js';
 import { doLogin } from './login.js';
 
 const { ux: cli } = CliUx;
+
+const debug = Debug('saleor-cli:register');
 
 export const command = 'register';
 export const desc = 'Create Saleor account';
@@ -21,6 +24,8 @@ export const builder: CommandBuilder = (_) =>
   });
 
 export const handler = async (argv: Arguments) => {
+  debug(`command arguments: ${JSON.stringify(argv, null, 2)}`);
+
   await doRegister(argv.fromCli as boolean);
 };
 

--- a/src/cli/storefront/create.ts
+++ b/src/cli/storefront/create.ts
@@ -1,4 +1,5 @@
 import chalk from 'chalk';
+import Debug from 'debug';
 import { access } from 'fs/promises';
 import kebabCase from 'lodash.kebabcase';
 import { customAlphabet } from 'nanoid';
@@ -20,6 +21,8 @@ import { useEnvironment } from '../../middleware/index.js';
 import { StoreCreate } from '../../types.js';
 import { setupGitRepository } from '../app/create.js';
 import { createEnvironment } from '../env/create.js';
+
+const debug = Debug('saleor-cli:storefront:create');
 
 export const command = 'create [name]';
 export const desc = 'Bootstrap example [name]';
@@ -43,7 +46,10 @@ export const builder: CommandBuilder = (_) =>
     });
 
 export const handler = async (argv: Arguments<StoreCreate>): Promise<void> => {
+  debug(`command arguments: ${JSON.stringify(argv, null, 2)}`);
+
   if (argv.environment) {
+    debug(`creating storefront for ${argv.environment}`);
     await createStorefront({
       ...argv,
       ...{ environment: argv.environment },
@@ -53,8 +59,13 @@ export const handler = async (argv: Arguments<StoreCreate>): Promise<void> => {
   }
 
   if (argv.demo) {
+    debug('demo mode');
+
+    debug('creating project');
     const project = await createProject(argv);
+    debug('preparing the environment');
     const environment = await prepareEnvironment(argv, project);
+    debug('creating storefront');
     await createStorefront({
       ...argv,
       ...{ environment: environment.key },

--- a/src/cli/storefront/deploy.ts
+++ b/src/cli/storefront/deploy.ts
@@ -1,4 +1,5 @@
 import chalk from 'chalk';
+import Debug from 'debug';
 import fs from 'fs-extra';
 import GitUrlParse from 'git-url-parse';
 import path from 'path';
@@ -12,6 +13,8 @@ import {
   getRepoUrl,
   triggerDeploymentInVercel,
 } from '../app/deploy.js';
+
+const debug = Debug('saleor-cli:storefront:deploy');
 
 export const command = 'deploy';
 export const desc = 'Deploy this `react-storefront` to Vercel';
@@ -32,8 +35,11 @@ export const handler = async () => {
   const { owner, name: repoName } = GitUrlParse(repoUrl);
 
   const { vercel_token: vercelToken } = await Config.get();
+  debug(`Your Vercel token: ${vercelToken}`);
+
   const vercel = new Vercel(vercelToken);
   console.log('\nDeploying to Vercel');
+
   // 2. Create a project in Vercel
   const { projectId, newProject } = await createProjectInVercel(
     vercel,
@@ -43,7 +49,10 @@ export const handler = async () => {
     'cd ../.. && npx turbo run build --filter="storefront..."',
     'apps/storefront'
   );
+  debug(`created a project in Vercel: ${projectId}`);
+
   // 3. Deploy the project in Vercel
+  debug('triggering the deployment');
   await triggerDeploymentInVercel(vercel, name, owner, projectId, newProject);
 
   process.exit(0);

--- a/src/cli/telemetry/disable.ts
+++ b/src/cli/telemetry/disable.ts
@@ -1,12 +1,15 @@
 import chalk from 'chalk';
-import type { CommandBuilder } from 'yargs';
+import Debug from 'debug';
 
 import { Config } from '../../lib/config.js';
+import { NoCommandBuilderSetup } from '../../lib/index.js';
+
+const debug = Debug('saleor-cli:telemetry:disable');
 
 export const command = 'disable';
 export const desc = 'Disable the telemetry';
 
-export const builder: CommandBuilder = (_) => _;
+export const builder = NoCommandBuilderSetup;
 
 export const handler = async () => {
   console.log(`${chalk.gray('Saleor Commerce CLI')} · Telemetry\n`);

--- a/src/cli/telemetry/enable.ts
+++ b/src/cli/telemetry/enable.ts
@@ -1,12 +1,15 @@
 import chalk from 'chalk';
-import type { CommandBuilder } from 'yargs';
+import Debug from 'debug';
 
 import { Config } from '../../lib/config.js';
+import { NoCommandBuilderSetup } from '../../lib/index.js';
+
+const debug = Debug('saleor-cli:telemetry:enable');
 
 export const command = 'enable';
 export const desc = 'Enable the telemetry';
 
-export const builder: CommandBuilder = (_) => _;
+export const builder = NoCommandBuilderSetup;
 
 export const handler = async () => {
   console.log(`${chalk.gray('Saleor Commerce CLI')} · Telemetry\n`);

--- a/src/cli/telemetry/status.ts
+++ b/src/cli/telemetry/status.ts
@@ -1,12 +1,15 @@
 import chalk from 'chalk';
-import type { CommandBuilder } from 'yargs';
+import Debug from 'debug';
 
 import { Config } from '../../lib/config.js';
+import { NoCommandBuilderSetup } from '../../lib/index.js';
+
+const debug = Debug('saleor-cli:telemetry:status');
 
 export const command = ['status', '$0'];
 export const desc = 'Show the telemetry status';
 
-export const builder: CommandBuilder = (_) => _;
+export const builder = NoCommandBuilderSetup;
 
 export const handler = async () => {
   console.log(`${chalk.gray('Saleor Commerce CLI')} · Telemetry\n`);

--- a/src/cli/trigger.ts
+++ b/src/cli/trigger.ts
@@ -1,4 +1,5 @@
 import chalk from 'chalk';
+import Debug from 'debug';
 import Enquirer from 'enquirer';
 import { request } from 'graphql-request';
 import type { Arguments, CommandBuilder } from 'yargs';
@@ -15,6 +16,8 @@ import {
 } from '../middleware/index.js';
 import { Options } from '../types.js';
 
+const debug = Debug('saleor-cli:trigger');
+
 export const command = 'trigger [event]';
 export const desc = 'This triggers a Saleor event';
 
@@ -22,6 +25,8 @@ export const builder: CommandBuilder = (_) =>
   _.option('event', { type: 'string' }).option('id', { type: 'string' });
 
 export const handler = async (argv: Arguments<Options>) => {
+  debug(`command arguments: ${JSON.stringify(argv, null, 2)}`);
+
   const { id } = argv;
   let { event } = argv;
 

--- a/src/cli/vercel/login.ts
+++ b/src/cli/vercel/login.ts
@@ -1,25 +1,28 @@
 import { CliUx } from '@oclif/core';
 import chalk from 'chalk';
+import Debug from 'debug';
 import EventEmitter from 'events';
 import got from 'got';
 import { nanoid } from 'nanoid';
 import { ServerApp } from 'retes';
 import { Response } from 'retes/response';
 import { GET } from 'retes/route';
-import type { CommandBuilder } from 'yargs';
 
 import { Config, SaleorCLIPort } from '../../lib/config.js';
 import { checkPort } from '../../lib/detectPort.js';
+import { NoCommandBuilderSetup } from '../../lib/index.js';
 import { delay } from '../../lib/util.js';
 
 const { ux: cli } = CliUx;
 
 const RedirectURI = `http://localhost:${SaleorCLIPort}/vercel/callback`;
 
+const debug = Debug('saleor-cli:vercel:login');
+
 export const command = 'login';
 export const desc = 'Add integration for Saleor CLI';
 
-export const builder: CommandBuilder = (_) => _;
+export const builder = NoCommandBuilderSetup;
 
 export const handler = async () => {
   await checkPort(SaleorCLIPort);

--- a/src/cli/webhook/create.ts
+++ b/src/cli/webhook/create.ts
@@ -1,4 +1,5 @@
 import chalk from 'chalk';
+import Debug from 'debug';
 import Enquirer from 'enquirer';
 import got from 'got';
 import { request } from 'graphql-request';
@@ -16,12 +17,16 @@ import { without } from '../../lib/util.js';
 import { interactiveSaleorApp } from '../../middleware/index.js';
 import { Options } from '../../types.js';
 
+const debug = Debug('saleor-cli:webhook:create');
+
 export const command = 'create';
 export const desc = 'Create a new webhook';
 
 export const builder: CommandBuilder = (_) => _;
 
 export const handler = async (argv: Arguments<Options>) => {
+  debug(`command arguments: ${JSON.stringify(argv, null, 2)}`);
+
   const { environment, app } = argv;
   const {
     __type: { enumValues: asyncEventsList },

--- a/src/cli/webhook/edit.ts
+++ b/src/cli/webhook/edit.ts
@@ -1,11 +1,13 @@
 import chalk from 'chalk';
+import Debug from 'debug';
 import Enquirer from 'enquirer';
 import got from 'got';
-import type { Arguments, CommandBuilder } from 'yargs';
+import type { Arguments } from 'yargs';
 
 import { doWebhookUpdate } from '../../graphql/doWebhookUpdate.js';
 import { Config } from '../../lib/config.js';
 import { getEnvironmentGraphqlEndpoint } from '../../lib/environment.js';
+import { NoCommandBuilderSetup } from '../../lib/index.js';
 import { validatePresence } from '../../lib/util.js';
 import {
   interactiveSaleorApp,
@@ -13,12 +15,15 @@ import {
 } from '../../middleware/index.js';
 import { Options } from '../../types.js';
 
+const debug = Debug('saleor-cli:webhook:edit');
+
 export const command = 'edit';
 export const desc = 'Edit a webhook';
 
-export const builder: CommandBuilder = (_) => _;
+export const builder = NoCommandBuilderSetup;
 
 export const handler = async (argv: Arguments<Options>) => {
+  debug(`command arguments: ${JSON.stringify(argv, null, 2)}`);
   const { environment, webhookID } = argv;
   const endpoint = await getEnvironmentGraphqlEndpoint(argv);
   const headers = await Config.getBearerHeader();

--- a/src/cli/webhook/list.ts
+++ b/src/cli/webhook/list.ts
@@ -1,5 +1,6 @@
 import { CliUx } from '@oclif/core';
 import chalk from 'chalk';
+import Debug from 'debug';
 import got from 'got';
 import { Arguments } from 'yargs';
 
@@ -11,10 +12,13 @@ import { Options } from '../../types.js';
 
 const { ux: cli } = CliUx;
 
+const debug = Debug('saleor-cli:webhook:list');
+
 export const command = 'list';
 export const desc = 'List webhooks for an environment';
 
 export const handler = async (argv: Arguments<Options>) => {
+  debug(`command arguments: ${JSON.stringify(argv, null, 2)}`);
   const endpoint = await getEnvironmentGraphqlEndpoint(argv);
   const headers = await Config.getBearerHeader();
 

--- a/src/cli/webhook/update.ts
+++ b/src/cli/webhook/update.ts
@@ -1,3 +1,4 @@
+import Debug from 'debug';
 import Enquirer from 'enquirer';
 import got from 'got';
 import ora from 'ora';
@@ -10,10 +11,13 @@ import { getEnvironmentGraphqlEndpoint } from '../../lib/environment.js';
 import { getAppsFromResult } from '../../lib/util.js';
 import { Options } from '../../types.js';
 
+const debug = Debug('saleor-cli:webhook:update');
+
 export const command = 'update';
 export const desc = 'Update webhooks for an environment';
 
 export const handler = async (argv: Arguments<Options>) => {
+  debug(`command arguments: ${JSON.stringify(argv, null, 2)}`);
   const endpoint = await getEnvironmentGraphqlEndpoint(argv);
   await updateWebhook(endpoint);
 };

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,7 +1,7 @@
 import Debug from 'debug';
 import type { CancelableRequest } from 'got';
 import got from 'got';
-import { Argv } from 'yargs';
+import { Argv, CommandBuilder } from 'yargs';
 
 import amplifyProdConfig from '../aws-exports-prod.js';
 import amplifyStagingConfig from '../aws-exports-staging.js'; // esl
@@ -106,7 +106,7 @@ export const API: Record<string, DefaultURLPath> = {
   DomainCheck: () => 'env-domain-check',
 };
 
-export const NoCommandBuilderSetup = (_: Argv) => _;
+export const NoCommandBuilderSetup: CommandBuilder = (_: Argv) => _;
 
 export const Region = 'us-east-1';
 export type Plan = 'startup' | 'pro' | 'dev' | 'enterprise' | 'staging';


### PR DESCRIPTION
**I want to merge this PR*** to add `debug` statements to all commands.



## Related issues

- #314

## Steps to test feature

- run with `DEBUG=saleor-cli:*`

## I have:

- [x] Tested it locally and it doesn't break existing features
