### PR TITLE
Verify name for `app deploy`

### DIFF
--- a/src/cli/app/deploy.ts
+++ b/src/cli/app/deploy.ts
@@ -13,7 +13,7 @@ import type { Arguments, CommandBuilder } from 'yargs';
 import { verifyIsSaleorAppDirectory } from '../../lib/common.js';
 import { Config } from '../../lib/config.js';
 import { getEnvironment } from '../../lib/environment.js';
-import { delay, readEnvFile } from '../../lib/util.js';
+import { delay, NameMismatchError, readEnvFile } from '../../lib/util.js';
 import { Deployment, Env, Vercel } from '../../lib/vercel.js';
 import {
   useEnvironment,
@@ -73,6 +73,15 @@ export const handler = async (argv: Arguments<Options>) => {
   const repoURL = await getRepoUrl(name);
   debug(`Remote Git repository: ${repoURL}`);
   const { owner, name: repoName } = GitUrlParse(repoURL);
+
+  debug(`Detected package name - "${name}". Repository name - "${repoName}"`);
+  if (name !== repoName) {
+    throw new NameMismatchError(
+      `Name from package.json - ${chalk.red(
+        name
+      )} - must be the same as the repository name - ${chalk.red(repoName)}`
+    );
+  }
 
   // 2. Create a project in Vercel
   const { projectId, newProject } = await createProjectInVercel(

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -50,6 +50,13 @@ export class SaleorAppInstallError extends Error {
   }
 }
 
+export class NameMismatchError extends Error {
+  constructor(message = '') {
+    super(message);
+    this.name = 'NameMismatchError';
+  }
+}
+
 // Higher-Order Creator for Prompts
 const createPrompt = async (
   name: string,


### PR DESCRIPTION
**I want to merge this PR because: **
The name from `package.json` have to be the same as git repository name


## Related issues

- https://github.com/saleor/saleor-cli/issues/341

## Steps to test feature

- create a saleor app `saleor app create`
- deploy an app `saleor app deploy`
- modify the name in `package.json`
- deploy an app `saleor app deploy`

## I have:

- [x] Tested it locally and it doesn't break existing features
- [ ] Added documentation if public changes are introduced
- [ ] Added tests for my code