### PR TITLE
Add the version explicitly to `dev info` output

### DIFF
--- a/src/cli/dev/info.ts
+++ b/src/cli/dev/info.ts
@@ -1,9 +1,16 @@
+import { createRequire } from 'module';
+
 import { run } from '../../lib/common.js';
 
 export const command = 'info';
 export const desc = 'Show env info for debugging';
 
 export const handler = async () => {
+  const require = createRequire(import.meta.url);
+  const pkg = require('../../../package.json');
+
+  console.log(`Saleor CLI v${pkg.version}`);
+
   await run(
     'npx',
     [


### PR DESCRIPTION
**I want to merge this PR to** have the CLI version in one place along with the OS versions.



## Related issues

- NA

## Steps to test feature

- NA

## I have:

- [X] Tested it locally and it doesn't break existing features
- [ ] Added documentation if public changes are introduced
- [ ] Added tests for my code