### PR TITLE
Update deploy commands

### DIFF
--- a/src/cli/app/deploy.ts
+++ b/src/cli/app/deploy.ts
@@ -1,14 +1,13 @@
 import chalk from 'chalk';
 import Debug from 'debug';
-import fs from 'fs-extra';
 import GitUrlParse from 'git-url-parse';
-import path from 'path';
 import type { Arguments, CommandBuilder } from 'yargs';
 
 import { verifyIsSaleorAppDirectory } from '../../lib/common.js';
 import { Config } from '../../lib/config.js';
 import {
   formatEnvironmentVariables,
+  getPackageName,
   getRepoUrl,
   triggerDeploymentInVercel,
 } from '../../lib/deploy.js';
@@ -52,10 +51,7 @@ export const builder: CommandBuilder = (_) =>
 export const handler = async (argv: Arguments<Options>) => {
   debug('command arguments: %O', argv);
 
-  debug('extracting the `name` from `package.json` of this Saleor App');
-  const { name } = JSON.parse(
-    await fs.readFile(path.join(process.cwd(), 'package.json'), 'utf-8')
-  );
+  const name = await getPackageName();
 
   console.log(
     `Deploying ${chalk.cyan(name)} (the name inferred from ${chalk.yellow(

--- a/src/cli/app/token.ts
+++ b/src/cli/app/token.ts
@@ -63,6 +63,7 @@ export const handler = async (argv: Arguments<Options>) => {
 export const createAppToken = async (url: string, app: string) => {
   const headers = await Config.getBearerHeader();
 
+  debug(`Getting app token for ${app}`);
   const { data }: any = await got
     .post(url, {
       headers,

--- a/src/cli/checkout/deploy.ts
+++ b/src/cli/checkout/deploy.ts
@@ -1,7 +1,6 @@
 import boxen from 'boxen';
 import chalk from 'chalk';
 import Debug from 'debug';
-import { customAlphabet } from 'nanoid';
 import { Arguments, CommandBuilder } from 'yargs';
 
 import { Config } from '../../lib/config.js';
@@ -14,18 +13,15 @@ import { Options } from '../../types.js';
 
 const debug = Debug('saleor-cli:checkout:deploy');
 
-export const command = 'deploy [name]';
+export const command = 'deploy';
 export const desc = 'Deploy `saleor-checkout` to Vercel';
-
-const nanoid = customAlphabet('1234567890abcdefghijklmnopqrstuvwxyz', 10);
 
 export const builder: CommandBuilder = NoCommandBuilderSetup;
 
-export const handler = async (argv: Arguments<Options & { name: string }>) => {
+export const handler = async (argv: Arguments<Options>) => {
   debug('command arguments: %O', argv);
 
-  const name = argv.name || `saleor-checkout-${nanoid(8).toLocaleLowerCase()}`;
-  debug(`Using the name: ${name}`);
+  // TODO prefill from .env
   const { domain } = await getEnvironment(argv);
   const url = `https://${domain}/graphql/`;
   debug(`Saleor endpoint: ${url}`);
@@ -39,14 +35,11 @@ export const handler = async (argv: Arguments<Options & { name: string }>) => {
   if (!vercelToken) {
     // TODO vercel_team_id
   } else {
-    const appName = `${name}-app-checkout`;
-    debug(`App name in Vercel: ${appName}`);
     const localEnvs = await readEnvFile();
 
     console.log('\nDeploying Checkout to Vercel');
     const { checkoutAppURL, authToken, appId } = await setupSaleorAppCheckout(
-      `${name}-app-checkout`,
-      localEnvs.SALEOR_API_URL,
+      localEnvs.SALEOR_API_URL, // FIXME url or localEnvs ?
       vercel,
       argv
     );

--- a/src/cli/checkout/deploy.ts
+++ b/src/cli/checkout/deploy.ts
@@ -1,21 +1,16 @@
 import boxen from 'boxen';
 import chalk from 'chalk';
-import crypto from 'crypto';
 import Debug from 'debug';
-import got from 'got';
 import { customAlphabet } from 'nanoid';
-import ora from 'ora';
 import { Arguments, CommandBuilder } from 'yargs';
 
-import { SaleorAppList } from '../../graphql/SaleorAppList.js';
-import { doSaleorAppInstall } from '../../lib/common.js';
 import { Config } from '../../lib/config.js';
+import { setupSaleorAppCheckout } from '../../lib/deploy.js';
 import { getEnvironment } from '../../lib/environment.js';
 import { NoCommandBuilderSetup } from '../../lib/index.js';
-import { delay } from '../../lib/util.js';
+import { readEnvFile } from '../../lib/util.js';
 import { Vercel } from '../../lib/vercel.js';
 import { Options } from '../../types.js';
-import { createAppToken } from '../app/token.js';
 
 const debug = Debug('saleor-cli:checkout:deploy');
 
@@ -44,69 +39,26 @@ export const handler = async (argv: Arguments<Options & { name: string }>) => {
   if (!vercelToken) {
     // TODO vercel_team_id
   } else {
-    // console.log("Using Vercel API")
-    const appName = `${name}-app`;
+    const appName = `${name}-app-checkout`;
     debug(`App name in Vercel: ${appName}`);
+    const localEnvs = await readEnvFile();
 
-    // SETUP CHECKOUT APP
-    await createCheckoutApp(vercelToken, appName, url);
-    const checkoutAppDeploymentId = await deployVercelProject(
-      vercelToken,
-      appName
-    );
-    await vercel.verifyDeployment(appName, checkoutAppDeploymentId);
-    const { alias } = await vercel.getDeployment(checkoutAppDeploymentId);
-    const checkoutAppURL = `https://${alias[0]}`;
-    debug(`Checkout App URL: ${checkoutAppURL}`);
-    const apiURL = `${checkoutAppURL}/api`;
-
-    // INSTALL APP IN CLOUD ENVIRONMENT
-    await doCheckoutAppInstall(argv, apiURL, appName);
-    const appId = await getAppId(url);
-    const authToken = await createAppToken(url, appId);
-
-    // CREATE SALEOR_APP_ID & SALEOR_APP_TOKEN variables in CHECKOUT APP
-    debug('Setting `SALEOR_APP_ID` and `SALEOR_APP_TOKEN`');
-    const appVars = [
-      {
-        type: 'encrypted',
-        key: 'SALEOR_APP_ID',
-        value: appId,
-        target: ['production', 'preview', 'development'],
-      },
-      {
-        type: 'encrypted',
-        key: 'SALEOR_APP_TOKEN',
-        value: authToken,
-        target: ['production', 'preview', 'development'],
-      },
-    ];
-    await createVercelEnv(vercelToken, appName, appVars);
-
-    // REDEPLOY
-    debug('Re-deploying the checkout');
-    const checkoutAppRedeploymentId = await deployVercelProject(
-      vercelToken,
-      appName
-    );
-    await vercel.verifyDeployment(
-      appName,
-      checkoutAppRedeploymentId,
-      'Redeploying'
+    console.log('\nDeploying Checkout to Vercel');
+    const { checkoutAppURL, authToken, appId } = await setupSaleorAppCheckout(
+      `${name}-app-checkout`,
+      localEnvs.SALEOR_API_URL,
+      vercel,
+      argv
     );
 
-    // SETUP CHECKOUT CRA
-    await createCheckout(vercelToken, name, checkoutAppURL, url);
-    const checkoutDeploymentId = await deployVercelProject(vercelToken, name);
-    await vercel.verifyDeployment(name, checkoutDeploymentId);
-    const { alias: checkoutAlias } = await vercel.getDeployment(
-      checkoutDeploymentId
-    );
+    localEnvs.CHECKOUT_APP_URL = checkoutAppURL;
+    localEnvs.CHECKOUT_STOREFRONT_URL = `${checkoutAppURL}/checkout-spa`;
+    localEnvs.SALEOR_APP_TOKEN = authToken;
+    localEnvs.SALEOR_APP_ID = appId;
 
     const appDashboardURL = `https://${domain}/dashboard/apps/${encodeURIComponent(
       appId
     )}/app`;
-    const checkoutURL = `https://${checkoutAlias[0]}`;
 
     const summary = `
   Your deployment is ready. Some useful links:
@@ -117,7 +69,7 @@ export const handler = async (argv: Arguments<Options & { name: string }>) => {
 
   Now, integrate your storefront with the checkout SPA:
   1. Copy the environment variable below.
-  ${chalk.blue(`NEXT_PUBLIC_CHECKOUT_URL=${checkoutURL}`)}
+  ${chalk.blue(`NEXT_PUBLIC_CHECKOUT_URL=${checkoutAppURL}`)}
   2. Paste it into the .env file in your React storefront.
   3. Re-run the development server.
 `;
@@ -131,215 +83,4 @@ export const handler = async (argv: Arguments<Options & { name: string }>) => {
       })
     );
   }
-
-  process.exit(0);
-};
-
-const createFork = async () => {
-  const { github_token: githubToken } = await Config.get();
-
-  const { id, full_name: fullName } = await got
-    .post('https://api.github.com/repos/saleor/saleor-checkout/forks', {
-      headers: {
-        Authorization: githubToken,
-      },
-    })
-    .json<{ id: string; full_name: string }>();
-
-  return {
-    id,
-    fullName,
-  };
-};
-
-const doCheckoutAppInstall = async (
-  argv: Options,
-  apiURL: string,
-  appName: string
-) => {
-  const { environment } = argv;
-  const spinner = ora(
-    `Installing ${appName} in the ${environment} environment...`
-  ).start();
-  const manifestURL = `${apiURL}/manifest`;
-  await doSaleorAppInstall({ ...argv, manifestURL, appName: 'Checkout' });
-  spinner.succeed(`Installed ${appName} in the ${environment} environment`);
-  await delay(2000);
-};
-
-const createCheckout = async (
-  vercelToken: string,
-  name: string,
-  checkoutAppUrl: string,
-  url: string
-) => {
-  const spinner = ora(`Creating ${name}...`).start();
-  const { fullName } = await createFork();
-
-  const response = await got
-    .post('https://api.vercel.com/v8/projects', {
-      headers: {
-        Authorization: vercelToken,
-      },
-      json: {
-        name,
-        environmentVariables: [
-          {
-            type: 'encrypted',
-            key: 'REACT_APP_CHECKOUT_APP_URL',
-            value: checkoutAppUrl,
-            target: ['production', 'preview', 'development'],
-          },
-          {
-            type: 'encrypted',
-            key: 'SALEOR_API_URL',
-            value: url,
-            target: ['production', 'preview', 'development'],
-          },
-          {
-            type: 'encrypted',
-            key: 'REACT_APP_SALEOR_API_URL',
-            value: url,
-            target: ['production', 'preview', 'development'],
-          },
-        ],
-        gitRepository: {
-          type: 'github',
-          repo: fullName,
-          sourceless: true,
-        },
-        framework: 'create-react-app',
-        buildCommand: 'cd ../.. && npx turbo run build --filter="checkout..."',
-        rootDirectory: 'apps/checkout',
-      },
-    })
-    .json();
-
-  spinner.succeed(`Created ${name}`);
-
-  return response;
-};
-
-const createCheckoutApp = async (
-  vercelToken: string,
-  name: string,
-  url: string
-) => {
-  const spinner = ora(`Creating ${name}...`).start();
-  const { fullName } = await createFork();
-
-  const secret = crypto.randomBytes(256).toString('hex');
-
-  const response = await got
-    .post('https://api.vercel.com/v8/projects', {
-      headers: {
-        Authorization: vercelToken,
-      },
-      json: {
-        name,
-        environmentVariables: [
-          {
-            type: 'encrypted',
-            key: 'SETTINGS_ENCRYPTION_SECRET',
-            value: secret,
-            target: ['production', 'preview', 'development'],
-          },
-          {
-            type: 'encrypted',
-            key: 'SALEOR_API_URL',
-            value: url,
-            target: ['production', 'preview', 'development'],
-          },
-          {
-            type: 'encrypted',
-            key: 'NEXT_PUBLIC_SALEOR_API_URL',
-            value: url,
-            target: ['production', 'preview', 'development'],
-          },
-        ],
-        gitRepository: {
-          type: 'github',
-          repo: fullName,
-          sourceless: true,
-        },
-        framework: 'nextjs',
-        buildCommand:
-          'cd ../.. && npx turbo run build --filter="saleor-app-checkout..."',
-        rootDirectory: 'apps/saleor-app-checkout',
-      },
-    })
-    .json();
-
-  spinner.succeed(`Created ${name}`);
-
-  return response;
-};
-
-const getAppId = async (url: string) => {
-  const headers = await Config.getBearerHeader();
-
-  const {
-    data: {
-      apps: { edges },
-    },
-  }: any = await got
-    .post(url, {
-      headers,
-      json: {
-        query: SaleorAppList,
-        variables: {},
-      },
-    })
-    .json();
-
-  if (!edges) {
-    throw console.error('No apps installed');
-  }
-
-  const [
-    {
-      node: { id },
-    },
-  ] = edges.slice(-1);
-
-  return id;
-};
-
-const deployVercelProject = async (vercelToken: string, name: string) => {
-  const { id } = await got
-    .post('https://api.vercel.com/v13/deployments', {
-      headers: {
-        Authorization: vercelToken,
-      },
-      json: {
-        gitSource: {
-          type: 'github',
-          ref: 'main',
-          repoId: 450152242, // saleor
-        },
-        name,
-        target: 'production',
-        source: 'import',
-      },
-    })
-    .json<{ id: string }>();
-
-  return id;
-};
-
-const createVercelEnv = async (
-  vercelToken: string,
-  name: string,
-  json: Record<string, unknown>[] | Record<string, unknown>
-) => {
-  const data = await got
-    .post(`https://api.vercel.com/v9/projects/${name}/env`, {
-      headers: {
-        Authorization: vercelToken,
-      },
-      json,
-    })
-    .json();
-
-  return data;
 };

--- a/src/cli/env/create.ts
+++ b/src/cli/env/create.ts
@@ -60,7 +60,7 @@ export const builder: CommandBuilder = (_) =>
     })
     .option('domain', {
       type: 'string',
-      desc: 'specify the domain for the envronment',
+      desc: 'specify the domain for the environment',
     })
     .option('email', {
       type: 'string',

--- a/src/cli/storefront/deploy.ts
+++ b/src/cli/storefront/deploy.ts
@@ -4,24 +4,38 @@ import fs from 'fs-extra';
 import GitUrlParse from 'git-url-parse';
 import path from 'path';
 import type { CommandBuilder } from 'yargs';
+import { Arguments } from 'yargs';
 
 import { Config } from '../../lib/config.js';
+import {
+  createProject,
+  getRepoUrl,
+  setupSaleorAppCheckout,
+} from '../../lib/deploy.js';
+import { readEnvFile } from '../../lib/util.js';
 import { Vercel } from '../../lib/vercel.js';
 import { useGithub, useVercel } from '../../middleware/index.js';
-import {
-  createProjectInVercel,
-  getRepoUrl,
-  triggerDeploymentInVercel,
-} from '../app/deploy.js';
+import { StoreDeploy } from '../../types.js';
+import { formatEnvs, triggerDeploymentInVercel } from '../app/deploy.js';
 
 const debug = Debug('saleor-cli:storefront:deploy');
 
 export const command = 'deploy';
 export const desc = 'Deploy this `react-storefront` to Vercel';
 
-export const builder: CommandBuilder = (_) => _;
+export const builder: CommandBuilder = (_) =>
+  _.option('dispatch', {
+    type: 'boolean',
+    demandOption: false,
+    default: false,
+    desc: 'dispatch deployment and don\'t wait till it ends',
+  }).option('with-checkout', {
+    type: 'boolean',
+    default: false,
+    desc: 'Deploy with checkout',
+  });
 
-export const handler = async () => {
+export const handler = async (argv: Arguments<StoreDeploy>) => {
   const { name } = JSON.parse(
     await fs.readFile(path.join(process.cwd(), 'package.json'), 'utf-8')
   );
@@ -31,31 +45,60 @@ export const handler = async () => {
     )})`
   );
 
-  const repoUrl = await getRepoUrl(name);
-  const { owner, name: repoName } = GitUrlParse(repoUrl);
-
   const { vercel_token: vercelToken } = await Config.get();
   debug(`Your Vercel token: ${vercelToken}`);
 
   const vercel = new Vercel(vercelToken);
-  console.log('\nDeploying to Vercel');
+  const localEnvs = await readEnvFile();
+  const repoUrl = await getRepoUrl(name);
 
-  // 2. Create a project in Vercel
-  const { projectId, newProject } = await createProjectInVercel(
+  if (argv.withCheckout) {
+    // Deploy checkout
+    console.log('\nDeploying Checkout to Vercel');
+    const { checkoutAppURL, authToken, appId } = await setupSaleorAppCheckout(
+      `${name}-app-checkout`,
+      localEnvs.SALEOR_API_URL,
+      vercel,
+      argv
+    );
+
+    localEnvs.CHECKOUT_APP_URL = checkoutAppURL;
+    localEnvs.CHECKOUT_STOREFRONT_URL = `${checkoutAppURL}/checkout-spa`;
+    localEnvs.SALEOR_APP_TOKEN = authToken;
+    localEnvs.SALEOR_APP_ID = appId;
+
+    // TODO save localEnvs to local .env
+  }
+
+  console.log('\nDeploying Storefront to Vercel');
+  const { id, newProject } = await createProject(
+    name,
+    vercel,
+    formatEnvs(localEnvs),
+    'storefront'
+  );
+  debug(`created a project in Vercel: ${id}`);
+
+  const { name: domain } = await vercel.getProjectDomain(id);
+  localEnvs.STOREFRONT_URL = `https://${domain}`;
+
+  // 2. Deploy the project in Vercel
+  debug('triggering the deployment');
+
+  const { owner } = GitUrlParse(repoUrl);
+  const deployment = await triggerDeploymentInVercel(
     vercel,
     name,
     owner,
-    repoName,
-    'cd ../.. && npx turbo run build --filter="storefront..."',
-    'apps/storefront'
+    id,
+    newProject
   );
-  debug(`created a project in Vercel: ${projectId}`);
 
-  // 3. Deploy the project in Vercel
-  debug('triggering the deployment');
-  await triggerDeploymentInVercel(vercel, name, owner, projectId, newProject);
-
-  process.exit(0);
+  const shouldWaitUntilDeployed = !!process.env.CI || !argv.dispatch;
+  if (shouldWaitUntilDeployed) {
+    const deploymentId = deployment.id || deployment.uid;
+    await vercel.verifyDeployment(name, deploymentId);
+  }
 };
 
 export const middlewares = [useVercel, useGithub];

--- a/src/cli/storefront/deploy.ts
+++ b/src/cli/storefront/deploy.ts
@@ -9,14 +9,15 @@ import { Arguments } from 'yargs';
 import { Config } from '../../lib/config.js';
 import {
   createProject,
+  formatEnvironmentVariables,
   getRepoUrl,
   setupSaleorAppCheckout,
+  triggerDeploymentInVercel,
 } from '../../lib/deploy.js';
 import { readEnvFile } from '../../lib/util.js';
 import { Vercel } from '../../lib/vercel.js';
 import { useGithub, useVercel } from '../../middleware/index.js';
 import { StoreDeploy } from '../../types.js';
-import { formatEnvs, triggerDeploymentInVercel } from '../app/deploy.js';
 
 const debug = Debug('saleor-cli:storefront:deploy');
 
@@ -74,7 +75,7 @@ export const handler = async (argv: Arguments<StoreDeploy>) => {
   const { id, newProject } = await createProject(
     name,
     vercel,
-    formatEnvs(localEnvs),
+    formatEnvironmentVariables(localEnvs),
     'storefront'
   );
   debug(`created a project in Vercel: ${id}`);

--- a/src/lib/common.ts
+++ b/src/lib/common.ts
@@ -48,7 +48,8 @@ export const doSaleorAppDelete = async (argv: any) => {
 };
 
 export const doSaleorAppInstall = async (argv: any) => {
-  const endpoint = await getEnvironmentGraphqlEndpoint(argv);
+  const endpoint =
+    argv.saleorApiUrl || (await getEnvironmentGraphqlEndpoint(argv));
   const headers = await Config.getBearerHeader();
 
   if (!argv.manifestURL) {

--- a/src/lib/deploy.ts
+++ b/src/lib/deploy.ts
@@ -1,0 +1,337 @@
+import chalk from 'chalk';
+import crypto from 'crypto';
+import Debug from 'debug';
+import Enquirer from 'enquirer';
+import GitUrlParse from 'git-url-parse';
+import got from 'got';
+import ora from 'ora';
+import simpleGit from 'simple-git';
+import { Arguments } from 'yargs';
+
+import { createAppToken } from '../cli/app/token';
+import { SaleorAppList } from '../graphql/SaleorAppList';
+import { Options } from '../types';
+import { doSaleorAppInstall } from './common';
+import { Config } from './config';
+import { delay } from './util';
+import { Env, Vercel } from './vercel';
+
+const debug = Debug('saleor-cli:lib:deploy');
+
+export const getAppId = async (url: string) => {
+  const headers = await Config.getBearerHeader();
+
+  // TODO use queryEnvironment
+  const {
+    data: {
+      apps: { edges },
+    },
+  }: any = await got
+    .post(url, {
+      headers,
+      json: {
+        query: SaleorAppList,
+        variables: {},
+      },
+    })
+    .json();
+
+  if (!edges) {
+    throw console.error('No apps installed');
+  }
+
+  const [
+    {
+      node: { id },
+    },
+  ] = edges.slice(-1);
+
+  return id;
+};
+
+export const createProject = async (
+  name: string,
+  vercel: Vercel,
+  envs: Env[],
+  app: string
+) => {
+  try {
+    debug('Verify if project exists in Vercel');
+    const project = await vercel.getProject(name);
+
+    project.newProject = false;
+    const spinner = ora(`Creating ${name}...`).start();
+    spinner.succeed(`Project ${name} already exists.`);
+
+    return project;
+  } catch {
+    debug('Project doesn\'t exist in Vercel, creating...');
+    const repoUrl = await getRepoUrl(name);
+    debug(`Repo URL: ${repoUrl}`);
+    const { owner, name: repoName } = GitUrlParse(repoUrl);
+
+    debug(`Owner: ${owner}, repoName: ${repoName}`);
+
+    const spinner = ora(`Creating ${name}...`).start();
+
+    const project = await vercel.createProject(
+      name,
+      envs,
+      owner,
+      repoName,
+      `cd ../.. && npx turbo run build --filter="${app}..."`,
+      `apps/${app}`,
+      'github'
+    );
+    project.newProject = true;
+
+    spinner.succeed(`Created ${name}`);
+    return project;
+  }
+};
+
+export const getRepoUrl = async (name: string): Promise<string> => {
+  const git = simpleGit();
+  const remotes = await git.getRemotes(true);
+  debug(`No of found remotes: ${remotes.length}`);
+  let gitUrl;
+
+  if (remotes.length > 0) {
+    gitUrl = (await git.remote(['get-url', 'origin'])) as string;
+  } else {
+    debug('Local repo doesn\'t exist, creating...');
+    gitUrl = await createProjectInGithub(name);
+  }
+
+  return gitUrl.trim();
+};
+
+const createProjectInGithub = async (name: string): Promise<string> => {
+  const git = simpleGit();
+  const { github_token: GitHubToken } = await Config.get();
+
+  const { githubProjectCreate } = (await Enquirer.prompt({
+    type: 'confirm',
+    name: 'githubProjectCreate',
+    initial: 'yes',
+    format: (value) => chalk.cyan(value ? 'yes' : 'no'),
+    message: 'Creating a project on your GitHub. Do you want to continue?',
+  })) as { githubProjectCreate: boolean };
+
+  if (!githubProjectCreate) {
+    console.error('Saleor App deployment cancelled by the user');
+    process.exit(1);
+  }
+
+  let gitRepoUrl;
+
+  interface CreateRepository {
+    createRepository: {
+      repository: {
+        sshUrl: string;
+      };
+    };
+  }
+
+  const { data, errors } = await got
+    .post('https://api.github.com/graphql', {
+      headers: {
+        Authorization: GitHubToken,
+      },
+      json: {
+        query: `mutation doRepositoryCreate($name: String!) {
+  createRepository(input: { name: $name, visibility: PRIVATE }) {
+          repository {
+      url
+      sshUrl
+    }
+  }
+} `,
+        variables: { name },
+      },
+    })
+    .json<{ data: CreateRepository; errors: Error[] }>();
+
+  if (errors) {
+    for (const error of errors) {
+      if (error.message === 'Name already exists on this account') {
+        console.log(`Pushing to the existing repository '${name}'`);
+        const repo = await getGithubRepository(name);
+        const {
+          viewer: {
+            repository: { sshUrl },
+          },
+        } = repo;
+        await git.addRemote('origin', sshUrl);
+        gitRepoUrl = sshUrl;
+      } else {
+        console.error(`\n ${chalk.red('ERROR')} ${error.message} `);
+        process.exit(1);
+      }
+    }
+  } else {
+    const {
+      createRepository: {
+        repository: { sshUrl },
+      },
+    } = data;
+    await git.addRemote('origin', sshUrl);
+    gitRepoUrl = sshUrl;
+  }
+
+  return gitRepoUrl;
+};
+
+export const getGithubRepository = async (
+  name: string,
+  owner: string | undefined = undefined
+): Promise<any> => {
+  const { github_token: GitHubToken } = await Config.get();
+
+  const query = owner
+    ? `query getRepository($name: String!, $owner: String!) {
+    repository(name: $name, owner: $owner) {
+      url
+      sshUrl
+      databaseId
+    }
+  }`
+    : `query getRepository($name: String!) {
+    viewer {
+    repository(name: $name) {
+      url
+      sshUrl
+      databaseId
+    }
+  }
+  }`;
+
+  const { data } = await got
+    .post('https://api.github.com/graphql', {
+      headers: { Authorization: GitHubToken },
+      json: {
+        query,
+        variables: { name, owner },
+      },
+    })
+    .json<{ data: unknown }>();
+
+  return data;
+};
+
+export const setupSaleorAppCheckout = async (
+  appName: string,
+  url: string,
+  vercel: Vercel,
+  argv: Arguments<Options>
+) => {
+  // SETUP CHECKOUT APP
+  const secret = crypto.randomBytes(256).toString('hex');
+  const envs = [
+    {
+      type: 'encrypted',
+      key: 'SETTINGS_ENCRYPTION_SECRET',
+      value: secret,
+      target: ['production', 'preview', 'development'],
+    },
+    {
+      type: 'encrypted',
+      key: 'SALEOR_API_URL',
+      value: url,
+      target: ['production', 'preview', 'development'],
+    },
+    {
+      type: 'encrypted',
+      key: 'NEXT_PUBLIC_SALEOR_API_URL',
+      value: url,
+      target: ['production', 'preview', 'development'],
+    },
+  ];
+
+  debug('Creating Checkout in Vercel');
+  const { env: vercelEnvs, id: projectId } = <{ env: Env[]; id: string }>(
+    await createProject(appName, vercel, envs, 'saleor-app-checkout')
+  );
+
+  // Verify if app already installed
+  if (vercelEnvs.map(({ key }) => key).includes('SALEOR_APP_ID')) {
+    debug('Checkout already exists');
+    // app already installed
+
+    const appId = vercelEnvs.filter(({ key }) => key === 'SALEOR_APP_ID')[0]
+      ?.value;
+    const authToken = vercelEnvs.filter(
+      ({ key }) => key === 'SALEOR_APP_TOKEN'
+    )[0]?.value;
+    const { name: domain } = await vercel.getProjectDomain(projectId);
+    const checkoutAppURL = `https://${domain}`;
+
+    return {
+      checkoutAppURL,
+      appId,
+      authToken,
+    };
+  }
+
+  const repoUrl = await getRepoUrl(appName);
+  const { owner, name: repoName } = GitUrlParse(repoUrl);
+
+  const {
+    repository: { databaseId: repoId },
+  } = await getGithubRepository(repoName, owner);
+
+  const { id: deploymentId } = await vercel.deploy(appName, 'github', repoId);
+  await vercel.verifyDeployment(appName, deploymentId);
+
+  const { alias } = await vercel.getDeployment(deploymentId);
+  const checkoutAppURL = `https://${alias[0]}`;
+  const apiURL = `${checkoutAppURL}/api`;
+
+  // INSTALL APP IN CLOUD ENVIRONMENT
+  await doCheckoutAppInstall({ ...argv, saleorApiUrl: url }, apiURL, appName);
+  const appId = await getAppId(url);
+  const authToken = await createAppToken(url, appId);
+
+  // CREATE SALEOR_APP_ID & SALEOR_APP_TOKEN variables in CHECKOUT APP
+  const appVars: Env[] = [
+    {
+      type: 'encrypted',
+      key: 'SALEOR_APP_ID',
+      value: appId,
+      target: ['production', 'preview', 'development'],
+    },
+    {
+      type: 'encrypted',
+      key: 'SALEOR_APP_TOKEN',
+      value: authToken,
+      target: ['production', 'preview', 'development'],
+    },
+  ];
+
+  await vercel.addEnvironmentVariables(projectId, appVars);
+
+  // REDEPLOY
+  const { id: redeploymentId } = await vercel.deploy(appName, 'github', repoId);
+  await vercel.verifyDeployment(appName, redeploymentId, 'Redeploying');
+
+  return {
+    checkoutAppURL,
+    appId,
+    authToken,
+  };
+};
+
+const doCheckoutAppInstall = async (
+  argv: Options,
+  apiURL: string,
+  appName: string
+) => {
+  const { environment } = argv;
+  const spinner = ora(
+    `Installing ${appName} in the ${environment} environment...`
+  ).start();
+  const manifestURL = `${apiURL}/manifest`;
+  await doSaleorAppInstall({ ...argv, manifestURL, appName });
+  spinner.succeed(`Installed ${appName} in the ${environment} environment`);
+  await delay(2000);
+};

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -1,14 +1,11 @@
 /* eslint-disable max-classes-per-file */
 import chalk from 'chalk';
 import { format } from 'date-fns';
-import dotenv from 'dotenv';
 import { emphasize } from 'emphasize';
 import Enquirer from 'enquirer';
-import fs from 'fs-extra';
 import got from 'got';
 import { lookpath } from 'lookpath';
 import ora from 'ora';
-import path from 'path';
 import yaml from 'yaml';
 
 import { SaleorAppByID } from '../graphql/SaleorAppByID.js';
@@ -549,19 +546,25 @@ export const verifyResultLength = (result: any[], entity: string) => {
   process.exit(0);
 };
 
-export const readEnvFile = async () => {
-  try {
-    return dotenv.parse(await fs.readFile(path.join(process.cwd(), '.env')));
-  } catch (error) {
-    return {};
-  }
-};
-
 export const getAppsFromResult = (result: any) => {
   const apps = result.apps?.edges;
   verifyResultLength(apps || [], 'app');
 
   return apps;
+};
+
+export const contentBox = (content: string, title = '') => {
+  const width = process.stdout.columns;
+  const wrappedTitle = title.length === 0 ? '' : chalk.blue(' ', title, ' ');
+  const headerLine = `──${wrappedTitle}${chalk
+    .blue('─')
+    .repeat(width - wrappedTitle.length - 2)}`;
+
+  console.log(headerLine);
+  console.log('');
+  console.log(content);
+  console.log('');
+  console.log(chalk.blue('─').repeat(width));
 };
 
 export const without = (name: string) => (record: any) => record.name !== name;

--- a/src/lib/vercel.ts
+++ b/src/lib/vercel.ts
@@ -91,10 +91,6 @@ export class Vercel {
     await this.addEnvironmentVariables(projectId, envs);
   }
 
-  async getProject(name: string) {
-    return this._client('GET', `/v9/projects/${name}`);
-  }
-
   async createProject(
     name: string,
     envs: Env[],
@@ -114,6 +110,7 @@ export class Vercel {
       gitRepository: {
         type: provider,
         repo: `${owner}/${repoName}`,
+        sourceless: true, // FIXME
       },
       framework: slug || 'nextjs',
       buildCommand,
@@ -176,6 +173,10 @@ export class Vercel {
     const URL = `https://${provider}.com/${owner}/${repoName}`;
 
     return this._client('GET', `/v1/integrations/detect-framework?url=${URL}`);
+  }
+
+  async getProject(name: string) {
+    return this._client('GET', `/v9/projects/${name}`);
   }
 
   async getProjectDomains(projectID: string) {

--- a/src/lib/vercel.ts
+++ b/src/lib/vercel.ts
@@ -13,6 +13,7 @@ export interface Env {
 
 export interface Deployment {
   id: string;
+  uid: string;
   url: string;
   readyState: string;
   alias: string;
@@ -110,7 +111,7 @@ export class Vercel {
       gitRepository: {
         type: provider,
         repo: `${owner}/${repoName}`,
-        sourceless: true, // FIXME
+        // sourceless: true, // FIXME
       },
       framework: slug || 'nextjs',
       buildCommand,

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,6 +29,7 @@ export interface Options extends BaseOptions {
   name?: string;
   encryptUrl?: string;
   registerUrl?: string;
+  saleorApiUrl?: string;
 }
 
 export interface CreatePromptResult {
@@ -58,6 +59,10 @@ export interface StoreCreate extends BaseOptions {
   name: string;
   auto?: boolean;
   environment?: string;
+}
+
+export interface StoreDeploy extends BaseOptions {
+  withCheckout: boolean;
 }
 
 export interface Environment {


### PR DESCRIPTION
## I want to merge this PR because:

It updates and unifies the deploy commands. 
It uses the `react-storefront` repository for checkout deployment.
It removes the `.env` dependency for deployment.
It unifies the deployment process.
It introduces `contentBox` instead of boxen ones for better handling of long texts/URLs

`saleor app deploy`
`saleor checkout deploy` 
`saleor storefront deploy`

## Related issues

- 

## Steps to test feature

- 

## I have:

- [x] Tested it locally and it doesn't break existing features
- [ ] Added documentation if public changes are introduced
- [ ] Added tests for my code