### PR TITLE
Add `status` command for better DX

### DIFF
--- a/docs/status.md
+++ b/docs/status.md
@@ -1,0 +1,12 @@
+## `saleor status` command
+
+```
+saleor status
+
+Show the login status for the systems that CLI depends on
+
+Options:
+      --json     Output the data as JSON                               [boolean]
+  -V, --version  Show version number                                   [boolean]
+  -h, --help     Show help                                             [boolean]
+```

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -26,6 +26,7 @@ import * as logout from './cli/logout.js';
 import organization from './cli/organization/index.js';
 import project from './cli/project/index.js';
 import * as register from './cli/register.js';
+import * as status from './cli/status.js';
 import storefront from './cli/storefront/index.js';
 import telemetry from './cli/telemetry/index.js';
 import * as trigger from './cli/trigger.js';
@@ -102,6 +103,7 @@ const parser = yargs(hideBin(process.argv))
   .alias('V', 'version')
   .usage('Usage: $0 <command> [options]')
   .command(info)
+  .command(status)
   .command(login)
   .command(logout)
   .command(configure)

--- a/src/cli/info.ts
+++ b/src/cli/info.ts
@@ -1,7 +1,6 @@
 import { CliUx } from '@oclif/core';
 import chalk from 'chalk';
 import Debug from 'debug';
-import { createRequire } from 'module';
 import type { CommandBuilder } from 'yargs';
 
 import pkg from '../../package.json';

--- a/src/cli/status.ts
+++ b/src/cli/status.ts
@@ -1,0 +1,45 @@
+import chalk from 'chalk';
+import Debug from 'debug';
+import type { CommandBuilder } from 'yargs';
+
+import pkg from '../../package.json';
+import { Config } from '../lib/config.js';
+
+const debug = Debug('saleor-cli:status');
+
+export const command = 'status';
+export const desc = 'Show the login status for the systems that CLI depends on';
+
+export const builder: CommandBuilder = (_) => _;
+export const handler = async (): Promise<void> => {
+  const {
+    token,
+    vercel_token: vercel,
+    github_token: github,
+  } = await Config.get();
+
+  console.log(`Saleor CLI v${pkg.version}`);
+  console.log('');
+
+  console.log(
+    ` Saleor API: ${
+      token
+        ? chalk.green('Logged')
+        : `${chalk.red('Not logged')}   Run: saleor login`
+    }`
+  );
+  console.log(
+    `     Vercel: ${
+      vercel
+        ? chalk.green('Logged')
+        : `${chalk.red('Not logged')}   Run: saleor vercel login`
+    }`
+  );
+  console.log(
+    `     GitHub: ${
+      github
+        ? chalk.green('Logged')
+        : `${chalk.red('Not logged')}   Run: saleor github login`
+    }`
+  );
+};


### PR DESCRIPTION
**I want to merge this PR** to provide the login status for the systems that CLI depends on.

<img width="842" alt="CleanShot 2022-09-14 at 10 39 21@2x" src="https://user-images.githubusercontent.com/200613/190105565-b0f170a6-e3d9-4f48-aa0b-d840fd950e13.png">


## Related issues

- #334 

## Steps to test feature

- `saleor status`

## I have:

- [x] Tested it locally and it doesn't break existing features
- [x] Added documentation if public changes are introduced
- [ ] Added tests for my code