### PR TITLE
Allow `got` as dep in the prod build

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "saleor": "./dist/saleor.js"
   },
   "scripts": {
-    "prepublishOnly": "rm -rf ./package && pnpm build && clean-publish --fields dependencies",
+    "prepublishOnly": "rm -rf ./package && pnpm build && clean-publish --fields dependencies && node -e \"let pkg=require('./package/package.json'); pkg.dependencies = { 'got': '^12.4.1' }; require('fs').writeFileSync('./package/package.json', JSON.stringify(pkg, null, 2));\"",
     "postpublish": "",
     "compile": "tsc",
     "bundle": "esbuild src/cli.ts --bundle --minify --outfile=dist/saleor.js --platform=node --format=esm --target=node16 --banner:js=\"import { createRequire } from 'module';const require = createRequire(import.meta.url);import { dirname } from 'path'; import { fileURLToPath } from 'url'; const __dirname = dirname(fileURLToPath(import.meta.url));\" --out-extension:.js=.js",


### PR DESCRIPTION
**I want to merge this PR to** install only `got` for the `scripts/`



## Related issues

- 

## Steps to test feature

- 

## I have:

- [x] Tested it locally and it doesn't break existing features
- [ ] Added documentation if public changes are introduced
- [ ] Added tests for my code