### PR TITLE
Define both prod & staging handlers for environment test

### DIFF
--- a/src/lib/environment.test.ts
+++ b/src/lib/environment.test.ts
@@ -8,8 +8,6 @@ import { Options } from '../types';
 import { getEnvironment, getEnvironmentGraphqlEndpoint } from './environment';
 import { configs } from './index';
 
-const CloudApiUrl = configs.staging.cloudApiUrl;
-
 const environment = {
   name: 'Test environment',
   slug: 'test-environment',
@@ -29,7 +27,11 @@ const handlers = [
     res(ctx.status(200), ctx.json(environment))
   ),
   rest.get(
-    `${CloudApiUrl}/organizations/${argv.organization}/environments/${argv.environment}`,
+    `${configs.production.cloudApiUrl}/organizations/${argv.organization}/environments/${argv.environment}`,
+    (req, res, ctx) => res(ctx.status(200), ctx.json(environment))
+  ),
+  rest.get(
+    `${configs.staging.cloudApiUrl}/organizations/${argv.organization}/environments/${argv.environment}`,
     (req, res, ctx) => res(ctx.status(200), ctx.json(environment))
   ),
 ];


### PR DESCRIPTION
**I want to merge this PR because: **
It adds endpoint handlers for both staging and production. This enables test to be run on any environment.


## Related issues

- 

## Steps to test feature

- 

## I have:

- [ ] Tested it locally and it doesn't break existing features
- [ ] Added documentation if public changes are introduced
- [ ] Added tests for my code