### PR TITLE
Fix the path for `dev info`

### DIFF
--- a/src/cli/dev/info.ts
+++ b/src/cli/dev/info.ts
@@ -1,14 +1,10 @@
-import { createRequire } from 'module';
-
+import pkg from '../../../package.json';
 import { run } from '../../lib/common.js';
 
 export const command = 'info';
 export const desc = 'Show env info for debugging';
 
 export const handler = async () => {
-  const require = createRequire(import.meta.url);
-  const pkg = require('../../../package.json');
-
   console.log(`Saleor CLI v${pkg.version}`);
 
   await run(


### PR DESCRIPTION
## I want to merge this PR because:

- it fixes the path import for `dev info` with `esbuild` setup

## Related issues

- #383 

## Steps to test feature

- 

## I have:

- [x] Tested it locally and it doesn't break existing features
- [ ] Added documentation if public changes are introduced
- [ ] Added tests for my code