### PR TITLE
Adjust `app tunnel` vendor for new bundling

### DIFF
--- a/src/cli/app/tunnel.ts
+++ b/src/cli/app/tunnel.ts
@@ -59,7 +59,7 @@ export const handler = async (argv: Arguments<Options>): Promise<void> => {
 
   debug(`Starting the tunnel with the port: ${argv.port}`);
   const __dirname = path.dirname(fileURLToPath(import.meta.url));
-  const vendorDir = path.join(__dirname, '..', '..', '..', 'vendor');
+  const vendorDir = path.join(__dirname, '..', 'vendor');
 
   debug('Extracting the Saleor app name');
   let appName;


### PR DESCRIPTION
## I want to merge this PR because:

- it adjusts the tunnel binary location for the new bundling approach introduced with `esbuild`


## Related issues

- NA

## Steps to test feature

- 

## I have:

- [X] Tested it locally and it doesn't break existing features
- [ ] Added documentation if public changes are introduced
- [ ] Added tests for my code