### PR TITLE
Allow to skip create GH repo prompt

### DIFF
--- a/src/cli/app/deploy.ts
+++ b/src/cli/app/deploy.ts
@@ -48,6 +48,12 @@ export const builder: CommandBuilder = (_) =>
       default: 'https://appraptor.vercel.app/api/encrypt',
       demandOption: false,
       desc: 'specify your own endpoint for encrypting tokens',
+    })
+    .option('github-prompt', {
+      type: 'boolean',
+      default: 'true',
+      demandOption: false,
+      desc: 'specify prompt presence for repository creation on Github',
     });
 
 export const handler = async (argv: Arguments<Options>) => {
@@ -67,7 +73,7 @@ export const handler = async (argv: Arguments<Options>) => {
   debug(`Your Vercel token: ${vercelToken}`);
   const vercel = new Vercel(vercelToken);
 
-  const repoURL = await getRepoUrl(name);
+  const repoURL = await getRepoUrl(name, argv.githubPrompt);
   debug(`Remote Git repository: ${repoURL}`);
   const { owner, name: repoName } = GitUrlParse(repoURL);
 

--- a/src/cli/checkout/deploy.ts
+++ b/src/cli/checkout/deploy.ts
@@ -8,7 +8,6 @@ import {
   getEnvironment,
   getEnvironmentGraphqlEndpoint,
 } from '../../lib/environment.js';
-import { NoCommandBuilderSetup } from '../../lib/index.js';
 import { contentBox } from '../../lib/util.js';
 import { Vercel } from '../../lib/vercel.js';
 import { Options } from '../../types.js';
@@ -18,7 +17,13 @@ const debug = Debug('saleor-cli:checkout:deploy');
 export const command = 'deploy';
 export const desc = 'Deploy `saleor-checkout` to Vercel';
 
-export const builder: CommandBuilder = NoCommandBuilderSetup;
+export const builder: CommandBuilder = (_) =>
+  _.option('github-prompt', {
+    type: 'boolean',
+    default: 'true',
+    demandOption: false,
+    desc: 'specify prompt presence for repository creation on Github',
+  });
 
 export const handler = async (argv: Arguments<Options>) => {
   debug('command arguments: %O', argv);

--- a/src/cli/storefront/deploy.ts
+++ b/src/cli/storefront/deploy.ts
@@ -6,7 +6,7 @@ import { Arguments } from 'yargs';
 
 import { Config } from '../../lib/config.js';
 import {
-  createProject,
+  createProjectInVercel,
   formatEnvironmentVariables,
   getPackageName,
   getRepoUrl,
@@ -33,11 +33,18 @@ export const builder: CommandBuilder = (_) =>
     demandOption: false,
     default: false,
     desc: 'dispatch deployment and don\'t wait till it ends',
-  }).option('with-checkout', {
-    type: 'boolean',
-    default: false,
-    desc: 'Deploy with checkout',
-  });
+  })
+    .option('with-checkout', {
+      type: 'boolean',
+      default: false,
+      desc: 'Deploy with checkout',
+    })
+    .option('github-prompt', {
+      type: 'boolean',
+      default: 'true',
+      demandOption: false,
+      desc: 'specify prompt presence for repository creation on Github',
+    });
 
 export const handler = async (argv: Arguments<StoreDeploy>) => {
   const name = await getPackageName();
@@ -52,7 +59,7 @@ export const handler = async (argv: Arguments<StoreDeploy>) => {
   debug(`Your Vercel token: ${vercelToken}`);
 
   const vercel = new Vercel(vercelToken);
-  const repoUrl = await getRepoUrl(name);
+  const repoUrl = await getRepoUrl(name, argv.githubPrompt);
 
   const endpoint = await getEnvironmentGraphqlEndpoint(argv);
   debug(`Saleor endpoint: ${endpoint}`);
@@ -78,7 +85,7 @@ export const handler = async (argv: Arguments<StoreDeploy>) => {
   }
 
   console.log('\nDeploying Storefront to Vercel');
-  const { id } = await createProject(
+  const { id } = await createProjectInVercel(
     name,
     vercel,
     formatEnvironmentVariables(envs),

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,6 +31,7 @@ export interface Options extends BaseOptions {
   encryptUrl?: string;
   registerUrl?: string;
   saleorApiUrl?: string;
+  githubPrompt?: boolean;
 }
 
 export interface CreatePromptResult {
@@ -64,6 +65,7 @@ export interface StoreCreate extends BaseOptions {
 
 export interface StoreDeploy extends BaseOptions {
   withCheckout: boolean;
+  githubPrompt?: boolean;
 }
 
 export interface Environment {


### PR DESCRIPTION
**I want to merge this PR because:**  is enables to skip repository creation prompt on Github. Use `--no-github-prompt` with `deploy` commands.



## Related issues
- [Enable non-interactive mode for deploy commands](https://github.com/saleor/saleor-cli/issues/386)


## Steps to test feature
Run one of commands below with `--no-github-prompt` argument

- `saleor app deploy`
- `saleor storefront deploy`
- `saleor checkout deploy`

## I have:

- [x] Tested it locally and it doesn't break existing features
- [ ] Added documentation if public changes are introduced
- [ ] Added tests for my code