### PR TITLE
Introduce set of functional tests for `deploy` commands

### DIFF
--- a/test/functional/app/deploy.test.ts
+++ b/test/functional/app/deploy.test.ts
@@ -1,0 +1,69 @@
+import crypto from 'crypto';
+import fs from 'fs-extra';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import {
+  command,
+  testEnvironmentName,
+  testOrganization,
+  trigger,
+} from '../../helper';
+
+const rand = crypto.randomBytes(256).toString('hex').substring(0, 7);
+const appName = `test-app-${rand}`;
+const storefrontCwd = `${process.cwd()}/${appName}`;
+
+beforeAll(async () => {
+  const params = ['app', 'create', appName];
+  console.log(`creating an app ${appName}`);
+  await trigger(command, params, {});
+}, 1000 * 600);
+
+afterAll(async () => {
+  await fs.remove(storefrontCwd);
+});
+
+describe('app deploy', async () => {
+  it(
+    'should deploy an app to Vercel',
+    async () => {
+      const params = [
+        'app',
+        'deploy',
+        '--no-github-prompt',
+        `--environment=${testEnvironmentName}`,
+        `--organization=${testOrganization}`,
+      ];
+      const { exitCode } = await trigger(
+        command,
+        params,
+        { cwd: storefrontCwd },
+        0
+      );
+
+      expect(exitCode).toBe(0);
+    },
+    1000 * 60 * 10
+  );
+
+  it(
+    'should re-deploy an app to Vercel',
+    async () => {
+      const params = [
+        'app',
+        'deploy',
+        `--environment=${testEnvironmentName}`,
+        `--organization=${testOrganization}`,
+      ];
+      const { exitCode } = await trigger(
+        command,
+        params,
+        { cwd: storefrontCwd },
+        0
+      );
+
+      expect(exitCode).toBe(0);
+    },
+    1000 * 60 * 10
+  );
+});

--- a/test/functional/checkout/deploy.test.ts
+++ b/test/functional/checkout/deploy.test.ts
@@ -1,0 +1,80 @@
+import crypto from 'crypto';
+import fs from 'fs-extra';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import {
+  command,
+  prepareEnvironment,
+  testEnvironmentName,
+  testOrganization,
+  trigger,
+} from '../../helper';
+
+const rand = crypto.randomBytes(256).toString('hex').substring(0, 7);
+const storefrontName = `storefront-${rand}`;
+const storefrontCwd = `${process.cwd()}/${storefrontName}`;
+
+beforeAll(async () => {
+  const environment = await prepareEnvironment();
+
+  const params = [
+    'store',
+    'create',
+    storefrontName,
+    `--environment=${environment}`,
+  ];
+  console.log(
+    `creating storefront ${storefrontName} with the ${environment} env`
+  );
+  await trigger(command, params, {});
+}, 1000 * 60 * 10);
+
+afterAll(async () => {
+  await fs.remove(storefrontCwd);
+}, 1000 * 60 * 10);
+
+describe('checkout deploy', async () => {
+  it(
+    'should deploy a checkout to Vercel',
+    async () => {
+      const params = [
+        'checkout',
+        'deploy',
+        '--no-github-prompt',
+        `--environment=${testEnvironmentName}`,
+        `--organization=${testOrganization}`,
+      ];
+      const { exitCode } = await trigger(
+        command,
+        params,
+        { cwd: storefrontCwd },
+        0
+      );
+
+      expect(exitCode).toBe(0);
+    },
+    1000 * 60 * 20
+  );
+
+  it(
+    'should re-deploy checkout with checkout to Vercel',
+    async () => {
+      const params = [
+        'checkout',
+        'deploy',
+        '--with-checkout',
+        `--environment=${testEnvironmentName}`,
+        `--organization=${testOrganization}`,
+      ];
+      const { exitCode } = await trigger(
+        command,
+        params,
+        { cwd: storefrontCwd },
+        0
+      );
+
+      expect(exitCode).toBe(0);
+    },
+    1000 * 60 * 10
+  );
+});

--- a/test/functional/environment/show.test.ts
+++ b/test/functional/environment/show.test.ts
@@ -1,0 +1,25 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+
+import { prepareEnvironment, testEnvironmentName, trigger } from '../../helper';
+
+beforeAll(async () => {
+  await prepareEnvironment();
+});
+
+describe('storefront show', async () => {
+  const command = 'saleor';
+
+  it('should return 0 exit code for valid env', async () => {
+    const params = ['env', 'show', testEnvironmentName];
+    const { exitCode } = await trigger(command, params, {}, 0);
+
+    expect(exitCode).toBe(0);
+  });
+
+  it('should return 1 exit code for invalid env', async () => {
+    const params = ['env', 'show', 'bla'];
+    const { exitCode } = await trigger(command, params, {}, 1);
+
+    expect(exitCode).not.toBe(0);
+  });
+});

--- a/test/functional/storefront/deploy.test.ts
+++ b/test/functional/storefront/deploy.test.ts
@@ -1,0 +1,81 @@
+import crypto from 'crypto';
+import fs from 'fs-extra';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import {
+  command,
+  prepareEnvironment,
+  testEnvironmentName,
+  testOrganization,
+  trigger,
+} from '../../helper';
+
+const rand = crypto.randomBytes(256).toString('hex').substring(0, 7);
+const storefrontName = `storefront-${rand}`;
+const storefrontCwd = `${process.cwd()}/${storefrontName}`;
+
+beforeAll(async () => {
+  const environment = await prepareEnvironment();
+
+  const params = [
+    'store',
+    'create',
+    storefrontName,
+    `--environment=${environment}`,
+  ];
+  console.log(
+    `creating storefront ${storefrontName} with the ${environment} env`
+  );
+  await trigger(command, params, {});
+}, 1000 * 60 * 10);
+
+afterAll(async () => {
+  await fs.remove(storefrontCwd);
+}, 1000 * 60 * 10);
+
+describe('storefront deploy', async () => {
+  it(
+    'should deploy a storefront with checkout to Vercel',
+    async () => {
+      const params = [
+        'storefront',
+        'deploy',
+        '--with-checkout',
+        '--no-github-prompt',
+        `--environment=${testEnvironmentName}`,
+        `--organization=${testOrganization}`,
+      ];
+      const { exitCode } = await trigger(
+        command,
+        params,
+        { cwd: storefrontCwd },
+        0
+      );
+
+      expect(exitCode).toBe(0);
+    },
+    1000 * 60 * 20
+  );
+
+  it(
+    'should re-deploy storefront with checkout to Vercel',
+    async () => {
+      const params = [
+        'storefront',
+        'deploy',
+        '--with-checkout',
+        `--environment=${testEnvironmentName}`,
+        `--organization=${testOrganization}`,
+      ];
+      const { exitCode } = await trigger(
+        command,
+        params,
+        { cwd: storefrontCwd },
+        0
+      );
+
+      expect(exitCode).toBe(0);
+    },
+    1000 * 60 * 10
+  );
+});

--- a/test/helper.ts
+++ b/test/helper.ts
@@ -1,0 +1,95 @@
+import { spawn } from 'child_process';
+
+export const trigger = async (
+  cmd: string,
+  params: string[],
+  options: {},
+  defaultCode = 0
+) => {
+  if (!shouldRunCommand) {
+    return {
+      output: [],
+      err: [],
+      exitCode: defaultCode,
+    };
+  }
+
+  const child = spawn('saleor', params, options);
+
+  const output: string[] = [];
+  for await (const data of child.stdout || []) {
+    output.push(data.toString());
+  }
+
+  const err: string[] = [];
+  for await (const data of child.stderr || []) {
+    err.push(data.toString());
+  }
+
+  const exitCode = await new Promise((resolve, _) => {
+    child.on('close', resolve);
+  });
+
+  if (err.length > 0) {
+    console.log(err);
+  }
+
+  return {
+    output,
+    err,
+    exitCode,
+  };
+};
+
+export const shouldRunCommand = !process.env.CI;
+export const command = 'saleor';
+export const testOrganization = 'cli-dev';
+export const testEnvironmentName = 'saleor-test';
+export const testProjectName = 'cli-test';
+
+export const getEnvironmentId = async (organization = testOrganization) => {
+  const params = [
+    'env',
+    'show',
+    testEnvironmentName,
+    `--organization=${organization}`,
+    '--json',
+  ];
+  const { output } = await trigger(command, params, {}, 0);
+  const { key } = <{ key: string }>(
+    JSON.parse(output.length > 0 ? output.join() : '{}')
+  );
+
+  return key;
+};
+
+export const prepareEnvironment = async () => {
+  await createTestEnvironment();
+  const environmentKey = await getEnvironmentId();
+
+  return environmentKey;
+};
+
+export const createTestEnvironment = async (
+  organization = testOrganization
+) => {
+  const params = [
+    'env',
+    'create',
+    testEnvironmentName,
+    `--project=${testProjectName}`,
+    '--database=sample',
+    '--saleor=saleor-master-staging',
+    '--domain=saleor-test-domain',
+    '--email=test@example.com',
+    '--skipRestrict',
+    '--deploy',
+    `--organization=${organization}`,
+  ];
+
+  const { err } = await trigger(command, params, {});
+
+  if (err.length > 0) {
+    throw new Error(err.join());
+  }
+};


### PR DESCRIPTION
## I want to merge this PR because 

- it introduces set of functional tests for `deploy` commands. Currently configured to run only on local machine.

## Related (issues, PRs, topics)

- https://github.com/saleor/saleor-cli/issues/260

## Steps to test feature

- `pnpm vitest`

## I have:

- [x] Tested it locally and it doesn't break existing features
- [ ] Added documentation if public changes are introduced
- [x] Added tests for my code
