### PR TITLE
Allow to skip dashboard admin email for `env create`

### DIFF
--- a/src/cli/env/create.ts
+++ b/src/cli/env/create.ts
@@ -164,6 +164,7 @@ export const createEnvironment = async (argv: Arguments<Options>) => {
       name: 'emailPrompt',
       message: 'Dashboard admin email',
       initial: argv.email || user.email,
+      skip: !!argv.email,
       validate: (value) => validateEmail(value),
     })) as { emailPrompt: string };
 


### PR DESCRIPTION
## I want to merge this PR because 

- It allows to skip dashboard admin email prompt for `environment creation`

## Related (issues, PRs, topics)

- [405](https://github.com/saleor/saleor-cli/issues/405)

## Steps to test feature

- `saleor storefront create --demo`

## I have:

- [x] Tested it locally and it doesn't break existing features
- [ ] Added documentation if public changes are introduced
- [ ] Added tests for my code
