### PR TITLE
Use commit hash for `store create` & `app create`

### DIFF
--- a/src/cli/app/create.ts
+++ b/src/cli/app/create.ts
@@ -55,7 +55,11 @@ export const handler = async (argv: Arguments<StoreCreate>): Promise<void> => {
 
   const spinner = ora('Downloading...').start();
   debug('downloading the `master` app template');
-  await downloadFromGitHub('saleor/saleor-app-template', target);
+  await downloadFromGitHub(
+    'saleor/saleor-app-template',
+    target,
+    '659ed312a4930e38150276e0ea714efc6ccc22e3'
+  );
 
   process.chdir(target);
 

--- a/src/cli/storefront/create.ts
+++ b/src/cli/storefront/create.ts
@@ -187,7 +187,11 @@ export const createStorefront = async (argv: Arguments<StoreCreate>) => {
 
   const spinner = ora('Downloading...').start();
   const target = await getFolderName(sanitize(argv.name));
-  await downloadFromGitHub('saleor/react-storefront', target);
+  await downloadFromGitHub(
+    'saleor/react-storefront',
+    target,
+    'a5caa3f2580ad075faeee9d4a2125e77bc60f6d8'
+  );
 
   process.chdir(target);
   spinner.text = 'Creating .env...';

--- a/src/lib/download.ts
+++ b/src/lib/download.ts
@@ -7,21 +7,25 @@ import { promisify } from 'util';
 const pipeline = promisify(stream.pipeline);
 
 /* eslint-disable import/prefer-default-export */
-export const downloadFromGitHub = async (repo: string, dest: string) => {
-  const url = `https://github.com/${repo}/archive/master.tar.gz`;
+export const downloadFromGitHub = async (
+  repo: string,
+  dest: string,
+  source = 'master'
+) => {
+  const url = `https://github.com/${repo}/archive/${source}.tar.gz`;
   const downloadStream = got.stream(url);
-  const filePath = './master.tgz';
+  const filePath = `./${source}.tgz`;
   const fileWriterStream = fs.createWriteStream(filePath, { mode: 0o755 });
 
   try {
     await pipeline(downloadStream, fileWriterStream);
 
     await fs.ensureDir(dest);
-    await tar.x({ file: './master.tgz', cwd: dest, strip: 1 });
+    await tar.x({ file: filePath, cwd: dest, strip: 1 });
     await fs.remove(filePath);
   } catch (error) {
     console.error(`Something went wrong. ${error}`);
   }
 
-  fs.remove('./master.tgz');
+  fs.remove(filePath);
 };


### PR DESCRIPTION
## I want to merge this PR because 

- it sets the downloaded repository to specific commit hash

## Related (issues, PRs, topics)

- https://github.com/saleor/saleor-cli/issues/298

## Steps to test feature

- `saleor app create` - commit hash `a5caa3f2580ad075faeee9d4a2125e77bc60f6d8`
- `saleor store create` - commit hash `659ed312a4930e38150276e0ea714efc6ccc22e3`

## I have:

- [x] Tested it locally and it doesn't break existing features
- [ ] Added documentation if public changes are introduced
- [ ] Added tests for my code
