### PR TITLE
Use only stable/LTS Node.js versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "yargs": "^17.5.1"
   },
   "engines": {
-    "node": ">=16"
+    "node": "^16 || ^18 || ^20"
   },
   "pnpm": {
     "overrides": {


### PR DESCRIPTION
## I want to merge this PR because 

- it enforces the use of only stable/LTS Node.js versions

## Related (issues, PRs, topics)

- NA

## Steps to test feature

- 

## I have:

- [x] Tested it locally and it doesn't break existing features
- [ ] Added documentation if public changes are introduced
- [ ] Added tests for my code
