### PR TITLE
Fix the URL parsing for the instance arg

### DIFF
--- a/src/middleware/index.ts
+++ b/src/middleware/index.ts
@@ -71,16 +71,20 @@ export const useInstanceConnector = async (argv: Options) => {
   const { instance } = argv;
 
   if (instance) {
-    const instanceURL = instance.startsWith('http')
-      ? instance
-      : `https://${instance}`;
+    try {
+      const { protocol, host } = new URL(instance);
+      const instanceURL = `${protocol}//${host}`;
 
-    // TODO API Call for org & env
+      // TODO API Call for org & env
 
-    return {
-      ...(await useToken(argv)),
-      instance: instanceURL,
-    };
+      return {
+        ...(await useToken(argv)),
+        instance: instanceURL,
+      };
+    } catch (error) {
+      console.error('Provided URL is invalid');
+      process.exit(1);
+    }
   }
 
   const stacked = useInstanceAttacher({


### PR DESCRIPTION
## I want to merge this PR because 

- it provides a more comprehensive way to validate the instance URL provided as an argument

## Related (issues, PRs, topics)

- https://github.com/saleor/saleor-cli/issues/321

## Steps to test feature

- provide a valid URL
- provide invalid URL
- provide an URL with a pathname e.g. `https://foo.saleor.cloud/graphql/`
- provide an URL without protocol

## I have:

- [x] Tested it locally and it doesn't break existing features
- [ ] Added documentation if public changes are introduced
- [ ] Added tests for my code
