### PR TITLE
Fix args for `ping` on different OSes

### DIFF
--- a/src/middleware/index.ts
+++ b/src/middleware/index.ts
@@ -388,9 +388,9 @@ export const interactiveWebhook = async (argv: Options) => {
   return {};
 };
 
-export const useOnlineChecker = async (argv: Arguments) => {
+export const useOnlineChecker = async () => {
   try {
-    await util.promisify(exec)('ping -c 1 -t 1 1.1.1.1');
+    await util.promisify(exec)('ping -c 1 1.1.1.1');
   } catch (error) {
     console.error(
       `You are ${chalk.red(


### PR DESCRIPTION
## I want to merge this PR because 

- it fixes the `ping` arguments for different OSes

## Related (issues, PRs, topics)

- #428 

## Steps to test feature

- `saleor info` on Ubuntu

## I have:

- [x] Tested it locally and it doesn't break existing features
- [ ] Added documentation if public changes are introduced
- [ ] Added tests for my code
