### PR TITLE
Fix the online check for GitHub Actions

### DIFF
--- a/src/middleware/index.ts
+++ b/src/middleware/index.ts
@@ -389,15 +389,20 @@ export const interactiveWebhook = async (argv: Options) => {
 };
 
 export const useOnlineChecker = async () => {
-  try {
-    await util.promisify(exec)('ping -c 1 1.1.1.1');
-  } catch (error) {
-    console.error(
-      `You are ${chalk.red(
-        'offline'
-      )}. Saleor CLI requires Internet access to operate. Check your connection.`
-    );
-    process.exit(1);
+  // check only if not in CI
+  // `ping` doesn't work in GitHub Actions
+  // ref. https://github.com/actions/runner-images/issues/1519#issuecomment-683790054
+  if (!process.env.CI) {
+    try {
+      await util.promisify(exec)('ping -c 1 1.1.1.1');
+    } catch (error) {
+      console.error(
+        `You are ${chalk.red(
+          'offline'
+        )}. Saleor CLI requires Internet access to operate. Check your connection.`
+      );
+      process.exit(1);
+    }
   }
 };
 


### PR DESCRIPTION
## I want to merge this PR because 

- It fixes the online checker behaviour in GitHub Actions. `ping` [doesn't work in GitHub Actions](https://github.com/actions/runner-images/issues/1519#issuecomment-683790054)


## Related (issues, PRs, topics)

- #428 

## Steps to test feature

- Run any CLI command with `CI` set

## I have:

- [x] Tested it locally and it doesn't break existing features
- [ ] Added documentation if public changes are introduced
- [ ] Added tests for my code
