### PR TITLE
Obfuscate tokens for `debug`

### DIFF
--- a/src/cli/app/create.ts
+++ b/src/cli/app/create.ts
@@ -11,7 +11,11 @@ import { Arguments, CommandBuilder } from 'yargs';
 
 import { run } from '../../lib/common.js';
 import { downloadFromGitHub } from '../../lib/download.js';
-import { checkPnpmPresence, contentBox } from '../../lib/util.js';
+import {
+  checkPnpmPresence,
+  contentBox,
+  obfuscateArgv,
+} from '../../lib/util.js';
 import { useToken } from '../../middleware/index.js';
 import { StoreCreate } from '../../types.js';
 
@@ -32,7 +36,7 @@ export const builder: CommandBuilder = (_) =>
   });
 
 export const handler = async (argv: Arguments<StoreCreate>): Promise<void> => {
-  debug('command arguments: %O', argv);
+  debug('command arguments: %O', obfuscateArgv(argv));
 
   debug('check PNPM presence');
   await checkPnpmPresence('This Saleor App template');

--- a/src/cli/app/deploy.ts
+++ b/src/cli/app/deploy.ts
@@ -12,7 +12,12 @@ import {
   getRepoUrl,
   triggerDeploymentInVercel,
 } from '../../lib/deploy.js';
-import { contentBox, NameMismatchError } from '../../lib/util.js';
+import {
+  contentBox,
+  NameMismatchError,
+  obfuscate,
+  obfuscateArgv,
+} from '../../lib/util.js';
 import { Vercel } from '../../lib/vercel.js';
 import {
   useAppConfig,
@@ -54,7 +59,7 @@ export const builder: CommandBuilder = (_) =>
     });
 
 export const handler = async (argv: Arguments<Options>) => {
-  debug('command arguments: %O', argv);
+  debug('command arguments: %O', obfuscateArgv(argv));
 
   const name = await getPackageName();
 
@@ -67,7 +72,7 @@ export const handler = async (argv: Arguments<Options>) => {
   console.log(`Deployment destination: ${chalk.magenta('Vercel')}\n`);
 
   const { vercel_token: vercelToken } = await Config.get();
-  debug(`Your Vercel token: ${vercelToken}`);
+  debug(`Your Vercel token: ${obfuscate(vercelToken)}`);
   const vercel = new Vercel(vercelToken);
 
   const repoURL = await getRepoUrl(name, argv.githubPrompt);

--- a/src/cli/app/generate.ts
+++ b/src/cli/app/generate.ts
@@ -12,7 +12,12 @@ import { Arguments, CommandBuilder } from 'yargs';
 import { GetWebhookEventEnum } from '../../generated/graphql.js';
 import { verifyIsSaleorAppDirectory } from '../../lib/common.js';
 import { DefaultSaleorEndpoint } from '../../lib/index.js';
-import { capitalize, uncapitalize, without } from '../../lib/util.js';
+import {
+  capitalize,
+  obfuscateArgv,
+  uncapitalize,
+  without,
+} from '../../lib/util.js';
 import { Options } from '../../types.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -30,7 +35,7 @@ export const builder: CommandBuilder = (_) =>
   });
 
 export const handler = async (argv: Arguments<Options>) => {
-  debug('command arguments: %O', argv);
+  debug('command arguments: %O', obfuscateArgv(argv));
 
   const { resource } = argv;
 

--- a/src/cli/app/install.ts
+++ b/src/cli/app/install.ts
@@ -2,7 +2,7 @@ import Debug from 'debug';
 import { Arguments, CommandBuilder } from 'yargs';
 
 import { doSaleorAppInstall } from '../../lib/common.js';
-import { printContext } from '../../lib/util.js';
+import { obfuscateArgv, printContext } from '../../lib/util.js';
 import { useAppConfig, useInstanceConnector } from '../../middleware/index.js';
 import { Options } from '../../types.js';
 
@@ -28,7 +28,7 @@ export const builder: CommandBuilder = (_) =>
     });
 
 export const handler = async (argv: Arguments<Options>) => {
-  debug('command arguments: %O', argv);
+  debug('command arguments: %O', obfuscateArgv(argv));
 
   const { organization, environment } = argv;
 

--- a/src/cli/app/list.ts
+++ b/src/cli/app/list.ts
@@ -10,6 +10,7 @@ import { getEnvironmentGraphqlEndpoint } from '../../lib/environment.js';
 import {
   formatDateTime,
   getAppsFromResult,
+  obfuscateArgv,
   printContext,
 } from '../../lib/util.js';
 import {
@@ -27,7 +28,7 @@ export const command = 'list';
 export const desc = 'List installed Saleor Apps for an environment';
 
 export const handler = async (argv: Arguments<Options>) => {
-  debug('command arguments: %O', argv);
+  debug('command arguments: %O', obfuscateArgv(argv));
 
   const { organization, environment } = argv;
 

--- a/src/cli/app/permission.ts
+++ b/src/cli/app/permission.ts
@@ -7,7 +7,7 @@ import { Arguments, CommandBuilder } from 'yargs';
 import { AppUpdate, GetPermissionEnum } from '../../generated/graphql.js';
 import { Config } from '../../lib/config.js';
 import { getEnvironmentGraphqlEndpoint } from '../../lib/environment.js';
-import { printContext } from '../../lib/util.js';
+import { obfuscateArgv, printContext } from '../../lib/util.js';
 import {
   useEnvironment,
   useOrganization,
@@ -29,7 +29,7 @@ export const builder: CommandBuilder = (_) =>
   });
 
 export const handler = async (argv: Arguments<Options>) => {
-  debug('command arguments: %O', argv);
+  debug('command arguments: %O', obfuscateArgv(argv));
 
   const { organization, environment } = argv;
 

--- a/src/cli/app/token.ts
+++ b/src/cli/app/token.ts
@@ -8,7 +8,12 @@ import { AppTokenCreate } from '../../generated/graphql.js';
 import { SaleorAppList } from '../../graphql/SaleorAppList.js';
 import { Config } from '../../lib/config.js';
 import { getEnvironmentGraphqlEndpoint } from '../../lib/environment.js';
-import { contentBox, getAppsFromResult, printContext } from '../../lib/util.js';
+import {
+  contentBox,
+  getAppsFromResult,
+  obfuscateArgv,
+  printContext,
+} from '../../lib/util.js';
 import {
   useEnvironment,
   useOrganization,
@@ -29,7 +34,7 @@ export const builder: CommandBuilder = (_) =>
   });
 
 export const handler = async (argv: Arguments<Options>) => {
-  debug('command arguments: %O', argv);
+  debug('command arguments: %O', obfuscateArgv(argv));
 
   const { organization, environment } = argv;
 

--- a/src/cli/app/tunnel.ts
+++ b/src/cli/app/tunnel.ts
@@ -15,7 +15,7 @@ import {
   verifyIsSaleorAppDirectory,
 } from '../../lib/common.js';
 import { Config } from '../../lib/config.js';
-import { contentBox, delay } from '../../lib/util.js';
+import { contentBox, delay, obfuscateArgv } from '../../lib/util.js';
 import { useAppConfig, useInstanceConnector } from '../../middleware/index.js';
 import { Options } from '../../types.js';
 
@@ -37,7 +37,7 @@ export const builder: CommandBuilder = (_) =>
     .option('force-install', { type: 'boolean', default: false });
 
 export const handler = async (argv: Arguments<Options>): Promise<void> => {
-  debug('command arguments: %O', argv);
+  debug('command arguments: %O', obfuscateArgv(argv));
 
   debug(`Starting the tunnel with the port: ${argv.port}`);
   const __dirname = path.dirname(fileURLToPath(import.meta.url));

--- a/src/cli/app/uninstall.ts
+++ b/src/cli/app/uninstall.ts
@@ -3,7 +3,7 @@ import Debug from 'debug';
 import { Arguments, CommandBuilder } from 'yargs';
 
 import { doSaleorAppDelete } from '../../lib/common.js';
-import { printContext } from '../../lib/util.js';
+import { obfuscateArgv, printContext } from '../../lib/util.js';
 import { useAppConfig, useInstanceConnector } from '../../middleware/index.js';
 import { Options } from '../../types.js';
 
@@ -15,7 +15,7 @@ export const desc = 'Uninstall a Saleor App by name';
 export const builder: CommandBuilder = (_) => _;
 
 export const handler = async (argv: Arguments<Options>) => {
-  debug('command arguments: %O', argv);
+  debug('command arguments: %O', obfuscateArgv(argv));
 
   const { organization, environment } = argv;
 

--- a/src/cli/backup/create.ts
+++ b/src/cli/backup/create.ts
@@ -2,7 +2,7 @@ import Debug from 'debug';
 import type { Arguments, CommandBuilder } from 'yargs';
 
 import { API, POST } from '../../lib/index.js';
-import { showResult, waitForTask } from '../../lib/util.js';
+import { obfuscateArgv, showResult, waitForTask } from '../../lib/util.js';
 
 const debug = Debug('saleor-cli:backup:create');
 
@@ -17,7 +17,7 @@ export const builder: CommandBuilder = (_) =>
   });
 
 export const handler = async (argv: Arguments<any>) => {
-  debug('command arguments: %O', argv);
+  debug('command arguments: %O', obfuscateArgv(argv));
 
   const { name } = argv;
 

--- a/src/cli/backup/list.ts
+++ b/src/cli/backup/list.ts
@@ -4,7 +4,11 @@ import Debug from 'debug';
 import { Arguments } from 'yargs';
 
 import { API, GET } from '../../lib/index.js';
-import { formatDateTime, verifyResultLength } from '../../lib/util.js';
+import {
+  formatDateTime,
+  obfuscateArgv,
+  verifyResultLength,
+} from '../../lib/util.js';
 import { Options } from '../../types.js';
 
 const { ux: cli } = CliUx;
@@ -15,7 +19,7 @@ export const command = 'list [key|environment]';
 export const desc = 'List backups of the environment';
 
 export const handler = async (argv: Arguments<Options>) => {
-  debug('command arguments: %O', argv);
+  debug('command arguments: %O', obfuscateArgv(argv));
 
   debug(`Listing for ${argv.key}`);
   const result = (await GET(API.Backup, argv)) as any[];

--- a/src/cli/backup/restore.ts
+++ b/src/cli/backup/restore.ts
@@ -4,7 +4,11 @@ import type { Arguments, CommandBuilder } from 'yargs';
 
 import { getEnvironmentGraphqlEndpoint } from '../../lib/environment.js';
 import { API, PUT } from '../../lib/index.js';
-import { promptOrganizationBackup, waitForTask } from '../../lib/util.js';
+import {
+  obfuscateArgv,
+  promptOrganizationBackup,
+  waitForTask,
+} from '../../lib/util.js';
 import { Options } from '../../types.js';
 import { updateWebhook } from '../webhook/update.js';
 
@@ -25,7 +29,7 @@ export const builder: CommandBuilder = (_) =>
   });
 
 export const handler = async (argv: Arguments<Options>) => {
-  debug('command arguments: %O', argv);
+  debug('command arguments: %O', obfuscateArgv(argv));
 
   const from = await getBackup(argv);
 

--- a/src/cli/backup/show.ts
+++ b/src/cli/backup/show.ts
@@ -2,7 +2,7 @@ import Debug from 'debug';
 import type { Arguments, CommandBuilder } from 'yargs';
 
 import { API, GET, NoCommandBuilderSetup } from '../../lib/index.js';
-import { showResult } from '../../lib/util.js';
+import { obfuscateArgv, showResult } from '../../lib/util.js';
 import { Options } from '../../types.js';
 
 const debug = Debug('saleor-cli:backup:show');
@@ -13,7 +13,7 @@ export const desc = 'Show a specific backup';
 export const builder: CommandBuilder = NoCommandBuilderSetup;
 
 export const handler = async (argv: Arguments<Options>) => {
-  debug('command arguments: %O', argv);
+  debug('command arguments: %O', obfuscateArgv(argv));
 
   const result = (await GET(API.Backup, argv)) as any;
   showResult(result, argv);

--- a/src/cli/checkout/deploy.ts
+++ b/src/cli/checkout/deploy.ts
@@ -4,7 +4,7 @@ import { Arguments, CommandBuilder } from 'yargs';
 
 import { Config } from '../../lib/config.js';
 import { setupSaleorAppCheckout } from '../../lib/deploy.js';
-import { contentBox } from '../../lib/util.js';
+import { contentBox, obfuscate, obfuscateArgv } from '../../lib/util.js';
 import { Vercel } from '../../lib/vercel.js';
 import { Options } from '../../types.js';
 
@@ -22,7 +22,7 @@ export const builder: CommandBuilder = (_) =>
   });
 
 export const handler = async (argv: Arguments<Options>) => {
-  debug('command arguments: %O', argv);
+  debug('command arguments: %O', obfuscateArgv(argv));
 
   const domain = argv.instance;
   const endpoint = `${domain}/graphql/`;
@@ -32,7 +32,7 @@ export const handler = async (argv: Arguments<Options>) => {
   const { vercel_token: vercelToken, vercel_team_id: vercelTeamId } =
     await Config.get();
 
-  debug(`Your Vercel token: ${vercelToken}`);
+  debug(`Your Vercel token: ${obfuscate(vercelToken)}`);
   const vercel = new Vercel(vercelToken);
 
   if (!vercelToken) {

--- a/src/cli/configure.ts
+++ b/src/cli/configure.ts
@@ -6,7 +6,11 @@ import type { Arguments, CommandBuilder } from 'yargs';
 
 import { Config } from '../lib/config.js';
 import { API, GET } from '../lib/index.js';
-import { promptEnvironment, promptOrganization } from '../lib/util.js';
+import {
+  obfuscateArgv,
+  promptEnvironment,
+  promptOrganization,
+} from '../lib/util.js';
 import { Options } from '../types.js';
 
 const { ux: cli } = CliUx;
@@ -26,7 +30,7 @@ export const builder: CommandBuilder = (_) =>
   );
 
 export const handler = async (argv: Arguments<Options>) => {
-  debug('command arguments: %O', argv);
+  debug('command arguments: %O', obfuscateArgv(argv));
 
   const { token, force } = argv;
   const legitToken = await configure(token);

--- a/src/cli/dev/prepare.ts
+++ b/src/cli/dev/prepare.ts
@@ -6,6 +6,7 @@ import { Arguments } from 'yargs';
 
 import { run } from '../../lib/common.js';
 import { Config } from '../../lib/config.js';
+import { obfuscateArgv } from '../../lib/util.js';
 import { useGithub } from '../../middleware/index.js';
 
 interface Options {
@@ -18,7 +19,7 @@ export const command = 'prepare [branch|prURL]';
 export const desc = 'Build cli from branch or pull request URL';
 
 export const handler = async (argv: Arguments<Options>) => {
-  debug('command arguments: %O', argv);
+  debug('command arguments: %O', obfuscateArgv(argv));
 
   const git = simpleGit();
 

--- a/src/cli/env/clear.ts
+++ b/src/cli/env/clear.ts
@@ -2,7 +2,7 @@ import Debug from 'debug';
 import type { Arguments, CommandBuilder } from 'yargs';
 
 import { API, GET } from '../../lib/index.js';
-import { waitForTask } from '../../lib/util.js';
+import { obfuscateArgv, waitForTask } from '../../lib/util.js';
 import { Options } from '../../types.js';
 
 const debug = Debug('saleor-cli:env:clear');
@@ -18,7 +18,7 @@ export const builder: CommandBuilder = (_) =>
   });
 
 export const handler = async (argv: Arguments<Options>) => {
-  debug('command arguments: %O', argv);
+  debug('command arguments: %O', obfuscateArgv(argv));
   debug('sending the request to Saleor API');
   const result = (await GET(API.ClearDatabase, argv)) as any;
   await waitForTask(argv, result.task_id, 'Clearing', 'Yay! Database cleared!');

--- a/src/cli/env/create.ts
+++ b/src/cli/env/create.ts
@@ -9,6 +9,7 @@ import { API, GET, POST, PUT } from '../../lib/index.js';
 import {
   contentBox,
   deploy,
+  obfuscateArgv,
   validateEmail,
   validateLength,
   waitForTask,
@@ -84,7 +85,7 @@ export const builder: CommandBuilder = (_) =>
     });
 
 export const handler = async (argv: Arguments<Options>) => {
-  debug('command arguments: %O', argv);
+  debug('command arguments: %O', obfuscateArgv(argv));
 
   debug('creating environment');
   const result = await createEnvironment(argv);

--- a/src/cli/env/list.ts
+++ b/src/cli/env/list.ts
@@ -4,7 +4,11 @@ import Debug from 'debug';
 import { Arguments, CommandBuilder } from 'yargs';
 
 import { API, GET } from '../../lib/index.js';
-import { formatDateTime, verifyResultLength } from '../../lib/util.js';
+import {
+  formatDateTime,
+  obfuscateArgv,
+  verifyResultLength,
+} from '../../lib/util.js';
 
 const { ux: cli } = CliUx;
 
@@ -21,7 +25,7 @@ export const builder: CommandBuilder = (_) =>
   });
 
 export const handler = async (argv: Arguments) => {
-  debug('command arguments: %O', argv);
+  debug('command arguments: %O', obfuscateArgv(argv));
 
   const { extended } = argv;
   const result = (await GET(API.Environment, {

--- a/src/cli/env/populate.ts
+++ b/src/cli/env/populate.ts
@@ -2,7 +2,7 @@ import Debug from 'debug';
 import type { Arguments, CommandBuilder } from 'yargs';
 
 import { API, GET } from '../../lib/index.js';
-import { waitForTask } from '../../lib/util.js';
+import { obfuscateArgv, waitForTask } from '../../lib/util.js';
 import { Options } from '../../types.js';
 
 const debug = Debug('saleor-cli:env:populate');
@@ -18,7 +18,7 @@ export const builder: CommandBuilder = (_) =>
   });
 
 export const handler = async (argv: Arguments<Options>) => {
-  debug('command arguments: %O', argv);
+  debug('command arguments: %O', obfuscateArgv(argv));
 
   const result = (await GET(API.PopulateDatabase, argv)) as any;
   await waitForTask(

--- a/src/cli/env/promote.ts
+++ b/src/cli/env/promote.ts
@@ -3,7 +3,11 @@ import type { Arguments, CommandBuilder } from 'yargs';
 
 import { getEnvironment } from '../../lib/environment.js';
 import { API, PUT } from '../../lib/index.js';
-import { promptCompatibleVersion, showResult } from '../../lib/util.js';
+import {
+  obfuscateArgv,
+  promptCompatibleVersion,
+  showResult,
+} from '../../lib/util.js';
 import { useEnvironment } from '../../middleware/index.js';
 import { Options } from '../../types.js';
 
@@ -23,7 +27,7 @@ export const builder: CommandBuilder = (_) =>
   });
 
 export const handler = async (argv: Arguments<Options>) => {
-  debug('command arguments: %O', argv);
+  debug('command arguments: %O', obfuscateArgv(argv));
 
   const service = await getService(argv);
   const result = (await PUT(API.UpgradeEnvironment, argv, {

--- a/src/cli/env/remove.ts
+++ b/src/cli/env/remove.ts
@@ -4,7 +4,7 @@ import type { Arguments, CommandBuilder } from 'yargs';
 
 import { Config } from '../../lib/config.js';
 import { API, DELETE, GET } from '../../lib/index.js';
-import { confirmRemoval, waitForTask } from '../../lib/util.js';
+import { confirmRemoval, obfuscateArgv, waitForTask } from '../../lib/util.js';
 import { useEnvironment } from '../../middleware/index.js';
 import { Options, Task } from '../../types.js';
 
@@ -24,7 +24,7 @@ export const builder: CommandBuilder = (_) =>
   });
 
 export const handler = async (argv: Arguments<Options>) => {
-  debug('command arguments: %O', argv);
+  debug('command arguments: %O', obfuscateArgv(argv));
 
   const { environment } = argv;
 

--- a/src/cli/env/show.ts
+++ b/src/cli/env/show.ts
@@ -2,7 +2,7 @@ import Debug from 'debug';
 import type { Arguments, CommandBuilder } from 'yargs';
 
 import { getEnvironment } from '../../lib/environment.js';
-import { showResult } from '../../lib/util.js';
+import { obfuscateArgv, showResult } from '../../lib/util.js';
 import { useEnvironment } from '../../middleware/index.js';
 import { Options } from '../../types.js';
 
@@ -19,7 +19,7 @@ export const builder: CommandBuilder = (_) =>
   });
 
 export const handler = async (argv: Arguments<Options>) => {
-  debug('command arguments: %O', argv);
+  debug('command arguments: %O', obfuscateArgv(argv));
 
   const result = await getEnvironment(argv);
 

--- a/src/cli/env/switch.ts
+++ b/src/cli/env/switch.ts
@@ -3,7 +3,7 @@ import Debug from 'debug';
 import type { Arguments, CommandBuilder } from 'yargs';
 
 import { Config } from '../../lib/config.js';
-import { promptEnvironment } from '../../lib/util.js';
+import { obfuscateArgv, promptEnvironment } from '../../lib/util.js';
 
 type Options = {
   key?: string;
@@ -22,7 +22,7 @@ export const builder: CommandBuilder = (_) =>
   });
 
 export const handler = async (argv: Arguments<Options>) => {
-  debug('command arguments: %O', argv);
+  debug('command arguments: %O', obfuscateArgv(argv));
 
   const environment = await getEnvironment(argv);
 

--- a/src/cli/env/upgrade.ts
+++ b/src/cli/env/upgrade.ts
@@ -3,7 +3,11 @@ import type { Arguments, CommandBuilder } from 'yargs';
 
 import { getEnvironment } from '../../lib/environment.js';
 import { API, PUT } from '../../lib/index.js';
-import { promptCompatibleVersion, waitForTask } from '../../lib/util.js';
+import {
+  obfuscateArgv,
+  promptCompatibleVersion,
+  waitForTask,
+} from '../../lib/util.js';
 import { useEnvironment } from '../../middleware/index.js';
 import { Options } from '../../types.js';
 
@@ -20,7 +24,7 @@ export const builder: CommandBuilder = (_) =>
   });
 
 export const handler = async (argv: Arguments<Options>) => {
-  debug('command arguments: %O', argv);
+  debug('command arguments: %O', obfuscateArgv(argv));
 
   const env = await getEnvironment(argv);
   const service = await promptCompatibleVersion({

--- a/src/cli/job/list.ts
+++ b/src/cli/job/list.ts
@@ -4,7 +4,7 @@ import Debug from 'debug';
 import { Arguments, CommandBuilder } from 'yargs';
 
 import { API, GET } from '../../lib/index.js';
-import { formatDateTime } from '../../lib/util.js';
+import { formatDateTime, obfuscateArgv } from '../../lib/util.js';
 import { Options } from '../../types.js';
 
 const { ux: cli } = CliUx;
@@ -26,7 +26,7 @@ export const builder: CommandBuilder = (_) =>
   _.option('env', { type: 'string' });
 
 export const handler = async (argv: Arguments<Options>) => {
-  debug('command arguments: %O', argv);
+  debug('command arguments: %O', obfuscateArgv(argv));
   const result = (await GET(API.Job, argv)) as any[];
 
   cli.table(result, {

--- a/src/cli/organization/list.ts
+++ b/src/cli/organization/list.ts
@@ -4,7 +4,7 @@ import Debug from 'debug';
 import { Arguments } from 'yargs';
 
 import { API, GET } from '../../lib/index.js';
-import { verifyResultLength } from '../../lib/util.js';
+import { obfuscateArgv, verifyResultLength } from '../../lib/util.js';
 import { Options } from '../../types.js';
 
 const { ux: cli } = CliUx;
@@ -15,7 +15,7 @@ export const command = 'list';
 export const desc = 'List organizations';
 
 export const handler = async (argv: Arguments<Options>) => {
-  debug('command arguments: %O', argv);
+  debug('command arguments: %O', obfuscateArgv(argv));
 
   const result = (await GET(API.Organization, {
     ...argv,

--- a/src/cli/organization/permissions.ts
+++ b/src/cli/organization/permissions.ts
@@ -2,7 +2,7 @@ import Debug from 'debug';
 import type { Arguments, CommandBuilder } from 'yargs';
 
 import { API, GET } from '../../lib/index.js';
-import { showResult } from '../../lib/util.js';
+import { obfuscateArgv, showResult } from '../../lib/util.js';
 import { useOrganization } from '../../middleware/index.js';
 import { Options } from '../../types.js';
 
@@ -19,7 +19,7 @@ export const builder: CommandBuilder = (_) =>
   });
 
 export const handler = async (argv: Arguments<Options>) => {
-  debug('command arguments: %O', argv);
+  debug('command arguments: %O', obfuscateArgv(argv));
 
   const result = (await GET(API.OrganizationPermissions, {
     ...argv,

--- a/src/cli/organization/remove.ts
+++ b/src/cli/organization/remove.ts
@@ -4,7 +4,11 @@ import type { Arguments, CommandBuilder } from 'yargs';
 
 import { Config } from '../../lib/config.js';
 import { API, DELETE } from '../../lib/index.js';
-import { confirmRemoval, promptOrganization } from '../../lib/util.js';
+import {
+  confirmRemoval,
+  obfuscateArgv,
+  promptOrganization,
+} from '../../lib/util.js';
 import { Options } from '../../types.js';
 
 const debug = Debug('saleor-cli:org:remove');
@@ -23,7 +27,7 @@ export const builder: CommandBuilder = (_) =>
   });
 
 export const handler = async (argv: Arguments<Options>) => {
-  debug('command arguments: %O', argv);
+  debug('command arguments: %O', obfuscateArgv(argv));
   const organization = argv.slug
     ? { name: argv.slug, value: argv.slug }
     : await promptOrganization(argv);

--- a/src/cli/organization/show.ts
+++ b/src/cli/organization/show.ts
@@ -2,7 +2,7 @@ import Debug from 'debug';
 import type { Arguments, CommandBuilder } from 'yargs';
 
 import { API, GET } from '../../lib/index.js';
-import { showResult } from '../../lib/util.js';
+import { obfuscateArgv, showResult } from '../../lib/util.js';
 import { useOrganization } from '../../middleware/index.js';
 import { Options } from '../../types.js';
 
@@ -14,7 +14,7 @@ export const desc = 'Show a specific organization';
 export const builder: CommandBuilder = (_) => _;
 
 export const handler = async (argv: Arguments<Options>) => {
-  debug('command arguments: %O', argv);
+  debug('command arguments: %O', obfuscateArgv(argv));
   const result = (await GET(API.Organization, argv)) as any;
 
   showResult(result, argv);

--- a/src/cli/organization/switch.ts
+++ b/src/cli/organization/switch.ts
@@ -4,7 +4,7 @@ import type { Arguments, CommandBuilder } from 'yargs';
 
 import { Config } from '../../lib/config.js';
 import { API, GET } from '../../lib/index.js';
-import { promptOrganization } from '../../lib/util.js';
+import { obfuscateArgv, promptOrganization } from '../../lib/util.js';
 import { Options } from '../../types.js';
 
 const debug = Debug('saleor-cli:org:switch');
@@ -20,7 +20,7 @@ export const builder: CommandBuilder = (_) =>
   });
 
 export const handler = async (argv: Arguments<Options>) => {
-  debug('command arguments: %O', argv);
+  debug('command arguments: %O', obfuscateArgv(argv));
   const organization = await getOrganization(argv);
 
   await Config.set('organization_slug', organization.value);

--- a/src/cli/project/create.ts
+++ b/src/cli/project/create.ts
@@ -1,7 +1,7 @@
 import Debug from 'debug';
 import type { Arguments, CommandBuilder } from 'yargs';
 
-import { createProject } from '../../lib/util.js';
+import { createProject, obfuscateArgv } from '../../lib/util.js';
 import { ProjectCreate } from '../../types.js';
 
 const debug = Debug('saleor-cli:project:create');
@@ -25,6 +25,6 @@ export const builder: CommandBuilder = (_) =>
     });
 
 export const handler = async (argv: Arguments<ProjectCreate>) => {
-  debug('command arguments: %O', argv);
+  debug('command arguments: %O', obfuscateArgv(argv));
   await createProject(argv);
 };

--- a/src/cli/project/list.ts
+++ b/src/cli/project/list.ts
@@ -4,7 +4,7 @@ import Debug from 'debug';
 import { Arguments } from 'yargs';
 
 import { API, GET } from '../../lib/index.js';
-import { formatDateTime } from '../../lib/util.js';
+import { formatDateTime, obfuscateArgv } from '../../lib/util.js';
 import { Options } from '../../types.js';
 
 const { ux: cli } = CliUx;
@@ -15,7 +15,7 @@ export const command = 'list';
 export const desc = 'List projects';
 
 export const handler = async (argv: Arguments<Options>) => {
-  debug('command arguments: %O', argv);
+  debug('command arguments: %O', obfuscateArgv(argv));
   const result = (await GET(API.Project, argv)) as any[];
 
   cli.table(result, {

--- a/src/cli/project/remove.ts
+++ b/src/cli/project/remove.ts
@@ -3,7 +3,11 @@ import Debug from 'debug';
 import type { Arguments, CommandBuilder } from 'yargs';
 
 import { API, DELETE } from '../../lib/index.js';
-import { confirmRemoval, promptProject } from '../../lib/util.js';
+import {
+  confirmRemoval,
+  obfuscateArgv,
+  promptProject,
+} from '../../lib/util.js';
 import { Options } from '../../types.js';
 
 const debug = Debug('saleor-cli:project:remove');
@@ -22,7 +26,7 @@ export const builder: CommandBuilder = (_) =>
   });
 
 export const handler = async (argv: Arguments<Options>) => {
-  debug('command arguments: %O', argv);
+  debug('command arguments: %O', obfuscateArgv(argv));
   const project = argv.slug
     ? { name: argv.slug, value: argv.slug }
     : await promptProject(argv);

--- a/src/cli/project/show.ts
+++ b/src/cli/project/show.ts
@@ -2,7 +2,7 @@ import Debug from 'debug';
 import type { Arguments, CommandBuilder } from 'yargs';
 
 import { API, GET } from '../../lib/index.js';
-import { showResult } from '../../lib/util.js';
+import { obfuscateArgv, showResult } from '../../lib/util.js';
 import { interactiveProject } from '../../middleware/index.js';
 import { Options } from '../../types.js';
 
@@ -15,7 +15,7 @@ export const builder: CommandBuilder = (_) =>
   _.positional('project', { type: 'string', demandOption: false });
 
 export const handler = async (argv: Arguments<Options>) => {
-  debug('command arguments: %O', argv);
+  debug('command arguments: %O', obfuscateArgv(argv));
   const result = (await GET(API.Project, argv)) as any;
   showResult(result, argv);
 };

--- a/src/cli/register.ts
+++ b/src/cli/register.ts
@@ -4,6 +4,8 @@ import Debug from 'debug';
 import Enquirer from 'enquirer';
 import { Arguments, CommandBuilder } from 'yargs';
 
+import { obfuscateArgv } from '../lib/util';
+
 const { ux: cli } = CliUx;
 
 const debug = Debug('saleor-cli:register');
@@ -19,7 +21,7 @@ export const builder: CommandBuilder = (_) =>
   });
 
 export const handler = async (argv: Arguments) => {
-  debug('command arguments: %O', argv);
+  debug('command arguments: %O', obfuscateArgv(argv));
 
   const link = 'https://cloud.saleor.io/signup';
 

--- a/src/cli/storefront/create.ts
+++ b/src/cli/storefront/create.ts
@@ -15,6 +15,7 @@ import {
   capitalize,
   checkPnpmPresence,
   getSortedServices,
+  obfuscateArgv,
 } from '../../lib/util.js';
 import {
   useEnvironment,
@@ -50,7 +51,7 @@ export const builder: CommandBuilder = (_) =>
     });
 
 export const handler = async (argv: Arguments<StoreCreate>): Promise<void> => {
-  debug('command arguments: %O', argv);
+  debug('command arguments: %O', obfuscateArgv(argv));
 
   if (argv.demo) {
     debug('demo mode');

--- a/src/cli/storefront/deploy.ts
+++ b/src/cli/storefront/deploy.ts
@@ -13,6 +13,7 @@ import {
   setupSaleorAppCheckout,
   triggerDeploymentInVercel,
 } from '../../lib/deploy.js';
+import { obfuscate, obfuscateArgv } from '../../lib/util.js';
 import { Vercel } from '../../lib/vercel.js';
 import {
   useAppConfig,
@@ -47,7 +48,7 @@ export const builder: CommandBuilder = (_) =>
     });
 
 export const handler = async (argv: Arguments<StoreDeploy>) => {
-  debug('command arguments: %O', argv);
+  debug('command arguments: %O', obfuscateArgv(argv));
 
   const name = await getPackageName();
 
@@ -58,7 +59,7 @@ export const handler = async (argv: Arguments<StoreDeploy>) => {
   );
 
   const { vercel_token: vercelToken } = await Config.get();
-  debug(`Your Vercel token: ${vercelToken}`);
+  debug(`Your Vercel token: ${obfuscate(vercelToken)}`);
 
   const vercel = new Vercel(vercelToken);
   const repoUrl = await getRepoUrl(name, argv.githubPrompt);

--- a/src/cli/trigger.ts
+++ b/src/cli/trigger.ts
@@ -8,7 +8,7 @@ import * as SaleorGraphQL from '../generated/graphql.js';
 import { Config } from '../lib/config.js';
 import { getEnvironmentGraphqlEndpoint } from '../lib/environment.js';
 import { DefaultSaleorEndpoint } from '../lib/index.js';
-import { capitalize } from '../lib/util.js';
+import { capitalize, obfuscateArgv } from '../lib/util.js';
 import {
   useEnvironment,
   useOrganization,
@@ -25,7 +25,7 @@ export const builder: CommandBuilder = (_) =>
   _.option('event', { type: 'string' }).option('id', { type: 'string' });
 
 export const handler = async (argv: Arguments<Options>) => {
-  debug('command arguments: %O', argv);
+  debug('command arguments: %O', obfuscateArgv(argv));
 
   const { id } = argv;
   let { event } = argv;

--- a/src/cli/webhook/create.ts
+++ b/src/cli/webhook/create.ts
@@ -13,7 +13,7 @@ import { doWebhookCreate } from '../../graphql/doWebhookCreate.js';
 import { Config } from '../../lib/config.js';
 import { getEnvironmentGraphqlEndpoint } from '../../lib/environment.js';
 import { DefaultSaleorEndpoint } from '../../lib/index.js';
-import { without } from '../../lib/util.js';
+import { obfuscateArgv, without } from '../../lib/util.js';
 import { interactiveSaleorApp } from '../../middleware/index.js';
 import { Options } from '../../types.js';
 
@@ -25,7 +25,7 @@ export const desc = 'Create a new webhook';
 export const builder: CommandBuilder = (_) => _;
 
 export const handler = async (argv: Arguments<Options>) => {
-  debug('command arguments: %O', argv);
+  debug('command arguments: %O', obfuscateArgv(argv));
 
   const { environment, app } = argv;
   const {

--- a/src/cli/webhook/edit.ts
+++ b/src/cli/webhook/edit.ts
@@ -8,7 +8,7 @@ import { doWebhookUpdate } from '../../graphql/doWebhookUpdate.js';
 import { Config } from '../../lib/config.js';
 import { getEnvironmentGraphqlEndpoint } from '../../lib/environment.js';
 import { NoCommandBuilderSetup } from '../../lib/index.js';
-import { validatePresence } from '../../lib/util.js';
+import { obfuscateArgv, validatePresence } from '../../lib/util.js';
 import {
   interactiveSaleorApp,
   interactiveWebhook,
@@ -23,7 +23,7 @@ export const desc = 'Edit a webhook';
 export const builder = NoCommandBuilderSetup;
 
 export const handler = async (argv: Arguments<Options>) => {
-  debug('command arguments: %O', argv);
+  debug('command arguments: %O', obfuscateArgv(argv));
   const { environment, webhookID } = argv;
   const endpoint = await getEnvironmentGraphqlEndpoint(argv);
   const headers = await Config.getBearerHeader();

--- a/src/cli/webhook/list.ts
+++ b/src/cli/webhook/list.ts
@@ -7,7 +7,7 @@ import { Arguments } from 'yargs';
 import { WebhookList } from '../../graphql/WebhookList.js';
 import { Config } from '../../lib/config.js';
 import { getEnvironmentGraphqlEndpoint } from '../../lib/environment.js';
-import { getAppsFromResult } from '../../lib/util.js';
+import { getAppsFromResult, obfuscateArgv } from '../../lib/util.js';
 import { Options } from '../../types.js';
 
 const { ux: cli } = CliUx;
@@ -18,7 +18,7 @@ export const command = 'list';
 export const desc = 'List webhooks for an environment';
 
 export const handler = async (argv: Arguments<Options>) => {
-  debug('command arguments: %O', argv);
+  debug('command arguments: %O', obfuscateArgv(argv));
   const endpoint = await getEnvironmentGraphqlEndpoint(argv);
   const headers = await Config.getBearerHeader();
 

--- a/src/cli/webhook/update.ts
+++ b/src/cli/webhook/update.ts
@@ -8,7 +8,7 @@ import { doWebhookUpdate } from '../../graphql/doWebhookUpdate.js';
 import { WebhookList } from '../../graphql/WebhookList.js';
 import { Config } from '../../lib/config.js';
 import { getEnvironmentGraphqlEndpoint } from '../../lib/environment.js';
-import { getAppsFromResult } from '../../lib/util.js';
+import { getAppsFromResult, obfuscateArgv } from '../../lib/util.js';
 import { Options } from '../../types.js';
 
 const debug = Debug('saleor-cli:webhook:update');
@@ -17,7 +17,7 @@ export const command = 'update';
 export const desc = 'Update webhooks for an environment';
 
 export const handler = async (argv: Arguments<Options>) => {
-  debug('command arguments: %O', argv);
+  debug('command arguments: %O', obfuscateArgv(argv));
   const endpoint = await getEnvironmentGraphqlEndpoint(argv);
   await updateWebhook(endpoint);
 };

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -7,6 +7,7 @@ import got from 'got';
 import { lookpath } from 'lookpath';
 import ora from 'ora';
 import yaml from 'yaml';
+import { Arguments } from 'yargs';
 
 import { SaleorAppByID } from '../graphql/SaleorAppByID.js';
 import { SaleorAppList } from '../graphql/SaleorAppList.js';
@@ -114,6 +115,19 @@ export const makeRequestAppList = async (argv: any) => {
 //
 // P U B L I C
 //
+
+export const obfuscate = (value: string) => `${value.slice(0, 12)} ****`;
+export const obfuscateArgv = (argv: Arguments<Options>) => {
+  // immutable
+  // structuredClone, available from Node.js 17
+  const argvCopy = Object.fromEntries(Object.entries(argv));
+
+  if (argv.token) {
+    argvCopy.token = obfuscate(argv.token);
+  }
+
+  return argvCopy;
+};
 
 export const checkPnpmPresence = async (entity: string) => {
   const pnpm = await lookpath('pnpm');

--- a/src/middleware/index.ts
+++ b/src/middleware/index.ts
@@ -39,7 +39,6 @@ export const useToken = async ({ token }: Options) => {
 
   if (!token) {
     const config = await Config.get();
-    debug('useDefault', config);
     const { token: configToken } = config;
 
     if (configToken) {
@@ -134,7 +133,6 @@ export const useOrganization = async ({
 
   if (!organization) {
     const config = await Config.get();
-    debug('useDefault', config);
     const { organization_slug: organizationSlug } = config;
 
     if (organizationSlug) {
@@ -257,7 +255,6 @@ export const useEnvironment = async ({
     opts = { ...opts, ...{ environment: env.key } };
   } else {
     const config = await Config.get();
-    debug('useDefault', config);
     const { environment_id: environmentId } = config;
 
     if (environmentId) {


### PR DESCRIPTION
## I want to merge this PR because 

- it obfuscates tokens for `debug`

## Related (issues, PRs, topics)

- #329

## Steps to test feature

- Run any command with `DEBUG=saleor-cli:*` to see obfuscate tokens

## I have:

- [x] Tested it locally and it doesn't break existing features
- [ ] Added documentation if public changes are introduced
- [ ] Added tests for my code
