### PR TITLE
Set commit hash for app/store create

### DIFF
--- a/src/cli/app/create.ts
+++ b/src/cli/app/create.ts
@@ -16,7 +16,7 @@ import {
   contentBox,
   obfuscateArgv,
 } from '../../lib/util.js';
-import { useToken } from '../../middleware/index.js';
+import { useAppConfig, useToken } from '../../middleware/index.js';
 import { StoreCreate } from '../../types.js';
 
 const debug = Debug('saleor-cli:app:create');
@@ -29,11 +29,19 @@ export const builder: CommandBuilder = (_) =>
     type: 'string',
     demandOption: true,
     default: 'my-saleor-app',
-  }).option('dependencies', {
-    type: 'boolean',
-    default: true,
-    alias: 'deps',
-  });
+  })
+    .option('dependencies', {
+      type: 'boolean',
+      default: true,
+      alias: 'deps',
+    })
+    .option('commit', {
+      type: 'string',
+      default: '1e3de9d775f2715d988c4ef90aee9101ea30fb16',
+      alias: 'c',
+    });
+
+const SaleorAppTemplateRepo = 'saleor/saleor-app-template';
 
 export const handler = async (argv: Arguments<StoreCreate>): Promise<void> => {
   debug('command arguments: %O', obfuscateArgv(argv));
@@ -53,11 +61,7 @@ export const handler = async (argv: Arguments<StoreCreate>): Promise<void> => {
 
   const spinner = ora('Downloading...').start();
   debug('downloading the `master` app template');
-  await downloadFromGitHub(
-    'saleor/saleor-app-template',
-    target,
-    '659ed312a4930e38150276e0ea714efc6ccc22e3'
-  );
+  await downloadFromGitHub(SaleorAppTemplateRepo, target, argv.commit);
 
   process.chdir(target);
 

--- a/src/cli/storefront/create.ts
+++ b/src/cli/storefront/create.ts
@@ -17,12 +17,7 @@ import {
   getSortedServices,
   obfuscateArgv,
 } from '../../lib/util.js';
-import {
-  useEnvironment,
-  useInstanceAttacher,
-  useOrganization,
-  useToken,
-} from '../../middleware/index.js';
+import { useOrganization, useToken } from '../../middleware/index.js';
 import { StoreCreate } from '../../types.js';
 import { setupGitRepository } from '../app/create.js';
 import { createEnvironment } from '../env/create.js';
@@ -33,6 +28,8 @@ export const command = 'create [name]';
 export const desc = 'Bootstrap example [name]';
 
 const nanoid = customAlphabet('1234567890abcdefghijklmnopqrstuvwxyz', 10);
+
+const SaleorReactStorefrontRepo = 'saleor/react-storefront';
 
 export const builder: CommandBuilder = (_) =>
   _.positional('name', {
@@ -48,6 +45,11 @@ export const builder: CommandBuilder = (_) =>
     .option('environment', {
       type: 'string',
       desc: 'specify environment id',
+    })
+    .option('commit', {
+      type: 'string',
+      default: 'a5caa3f2580ad075faeee9d4a2125e77bc60f6d8',
+      alias: 'c',
     });
 
 export const handler = async (argv: Arguments<StoreCreate>): Promise<void> => {
@@ -186,13 +188,11 @@ const prepareEnvironment = async (
 export const createStorefront = async (argv: Arguments<StoreCreate>) => {
   await checkPnpmPresence('react-storefront project');
 
+  const { name, commit } = argv;
+
   const spinner = ora('Downloading...').start();
-  const target = await getFolderName(sanitize(argv.name));
-  await downloadFromGitHub(
-    'saleor/react-storefront',
-    target,
-    'a5caa3f2580ad075faeee9d4a2125e77bc60f6d8'
-  );
+  const target = await getFolderName(sanitize(name));
+  await downloadFromGitHub(SaleorReactStorefrontRepo, target, commit);
 
   process.chdir(target);
   spinner.text = 'Creating .env...';

--- a/src/middleware/index.ts
+++ b/src/middleware/index.ts
@@ -110,6 +110,7 @@ export const useInstanceAttacher = async (argv: Options) => {
 };
 
 export const useAppConfig = async (argv: Options) => {
+  console.log('before', argv);
   try {
     const content = await fs.readFile(
       path.join(process.cwd(), 'saleor.config.json'),

--- a/src/types.ts
+++ b/src/types.ts
@@ -61,6 +61,7 @@ export interface StoreCreate extends BaseOptions {
   name: string;
   auto?: boolean;
   environment?: string;
+  commit?: string;
 }
 
 export interface StoreDeploy extends BaseOptions {


### PR DESCRIPTION
## I want to merge this PR because 

- it allows to explicitly set the commit hash for `app create` and `storefront create`

## Related (issues, PRs, topics)

- #430

## Steps to test feature

- Pass `--commit` (or `-c`) for `app create` or `storefront create`

## I have:

- [x] Tested it locally and it doesn't break existing features
- [ ] Added documentation if public changes are introduced
- [ ] Added tests for my code
