### PR TITLE
Use name from manifest or app-name from argv for `app install`

### DIFF
--- a/src/lib/common.ts
+++ b/src/lib/common.ts
@@ -75,13 +75,10 @@ export const doSaleorAppInstall = async (argv: any) => {
     process.exit(1);
   }
 
-  const { name } = await Enquirer.prompt<{ name: string }>({
-    type: 'input',
-    name: 'name',
-    message: 'App name',
-    skip: !!argv.appName,
-    initial: argv.appName ?? manifest.name,
-  });
+  const name = argv.appName ?? manifest.name;
+  console.log(
+    chalk(chalk.green('✔'), chalk.bold('Name'), '·', chalk.green(name))
+  );
 
   if (!argv.viaDashboard) {
     const { data, errors }: any = await got


### PR DESCRIPTION
## I want to merge this PR because 

It simplifies app installation by removing the app name input prompt. The name is taken from manifest or from argv `app-name`

## Related (issues, PRs, topics)

- https://github.com/saleor/saleor-cli/issues/264

## Steps to test feature

- `saleor app install`

## I have:

- [x] Tested it locally and it doesn't break existing features
- [ ] Added documentation if public changes are introduced
- [ ] Added tests for my code
