### PR TITLE
Align project creation with Git clone

### DIFF
--- a/src/cli/app/create.ts
+++ b/src/cli/app/create.ts
@@ -11,7 +11,7 @@ import { Arguments, CommandBuilder } from 'yargs';
 
 import * as Config from '../../config.js';
 import { run } from '../../lib/common.js';
-import { downloadFromGitHub } from '../../lib/download.js';
+import { gitCopy } from '../../lib/download.js';
 import {
   checkPnpmPresence,
   contentBox,
@@ -36,10 +36,15 @@ export const builder: CommandBuilder = (_) =>
       default: true,
       alias: 'deps',
     })
-    .option('commit', {
+    .option('repository', {
       type: 'string',
-      default: Config.SaleorAppHash,
-      alias: 'c',
+      default: Config.SaleorAppRepo,
+      alias: ['repo', 'r'],
+    })
+    .option('branch', {
+      type: 'string',
+      default: Config.SaleorAppDefaultBranch,
+      alias: 'b',
     });
 
 export const handler = async (argv: Arguments<StoreCreate>): Promise<void> => {
@@ -48,8 +53,10 @@ export const handler = async (argv: Arguments<StoreCreate>): Promise<void> => {
   debug('check PNPM presence');
   await checkPnpmPresence('This Saleor App template');
 
+  const { name, repository, branch } = argv;
+
   debug('construct the folder name');
-  const target = await getFolderName(sanitize(argv.name));
+  const target = await getFolderName(sanitize(name));
   const packageName = kebabCase(target);
   const dirMsg = `App directory: ${chalk.blue(
     path.join(process.env.PWD || '.', target)
@@ -59,8 +66,8 @@ export const handler = async (argv: Arguments<StoreCreate>): Promise<void> => {
   contentBox(`    ${dirMsg}\n    ${appMsg}`);
 
   const spinner = ora('Downloading...').start();
-  debug('downloading the `master` app template');
-  await downloadFromGitHub(Config.SaleorAppRepo, target, argv.commit);
+  debug(`downloading the ${branch} app template`);
+  await gitCopy(repository, target, branch);
 
   process.chdir(target);
 

--- a/src/cli/app/create.ts
+++ b/src/cli/app/create.ts
@@ -36,10 +36,10 @@ export const builder: CommandBuilder = (_) =>
       default: true,
       alias: 'deps',
     })
-    .option('repository', {
+    .option('template', {
       type: 'string',
       default: Config.SaleorAppRepo,
-      alias: ['repo', 'r'],
+      alias: ['t', 'repo', 'repository'],
     })
     .option('branch', {
       type: 'string',
@@ -53,7 +53,7 @@ export const handler = async (argv: Arguments<StoreCreate>): Promise<void> => {
   debug('check PNPM presence');
   await checkPnpmPresence('This Saleor App template');
 
-  const { name, repository, branch } = argv;
+  const { name, template, branch } = argv;
 
   debug('construct the folder name');
   const target = await getFolderName(sanitize(name));
@@ -66,8 +66,9 @@ export const handler = async (argv: Arguments<StoreCreate>): Promise<void> => {
   contentBox(`    ${dirMsg}\n    ${appMsg}`);
 
   const spinner = ora('Downloading...').start();
+
   debug(`downloading the ${branch} app template`);
-  await gitCopy(repository, target, branch);
+  await gitCopy(template, target, branch);
 
   process.chdir(target);
 

--- a/src/cli/storefront/create.ts
+++ b/src/cli/storefront/create.ts
@@ -10,7 +10,7 @@ import { Arguments, CommandBuilder } from 'yargs';
 
 import * as Config from '../../config.js';
 import { run } from '../../lib/common.js';
-import { downloadFromGitHub } from '../../lib/download.js';
+import { gitCopy } from '../../lib/download.js';
 import { API, GET, POST } from '../../lib/index.js';
 import {
   capitalize,
@@ -45,10 +45,10 @@ export const builder: CommandBuilder = (_) =>
       type: 'string',
       desc: 'specify environment id',
     })
-    .option('repository', {
+    .option('template', {
       type: 'string',
       default: Config.SaleorStorefrontRepo,
-      alias: ['repo', 'r'],
+      alias: ['t'],
     })
     .option('branch', {
       type: 'string',
@@ -73,7 +73,7 @@ export const handler = async (argv: Arguments<StoreCreate>): Promise<void> => {
     debug('creating project');
     const project = await createProject(_argv);
     debug('preparing the environment');
-    const environment = await prepareEnvironment(_argv, project);
+    await prepareEnvironment(_argv, project);
     debug('creating storefront');
     await createStorefront(_argv);
   } else {
@@ -192,11 +192,11 @@ const prepareEnvironment = async (
 export const createStorefront = async (argv: Arguments<StoreCreate>) => {
   await checkPnpmPresence('react-storefront project');
 
-  const { name, repository, branch } = argv;
+  const { name, template, branch } = argv;
 
   const spinner = ora('Downloading...').start();
   const target = await getFolderName(sanitize(name));
-  await downloadFromGitHub(repository, target, branch);
+  await gitCopy(template, target, branch);
 
   process.chdir(target);
   spinner.text = 'Creating .env...';

--- a/src/cli/storefront/create.ts
+++ b/src/cli/storefront/create.ts
@@ -45,10 +45,15 @@ export const builder: CommandBuilder = (_) =>
       type: 'string',
       desc: 'specify environment id',
     })
-    .option('commit', {
+    .option('repository', {
       type: 'string',
-      default: Config.SaleorStorefrontHash,
-      alias: 'c',
+      default: Config.SaleorStorefrontRepo,
+      alias: ['repo', 'r'],
+    })
+    .option('branch', {
+      type: 'string',
+      default: Config.SaleorStorefrontDefaultBranch,
+      alias: 'b',
     });
 
 export const handler = async (argv: Arguments<StoreCreate>): Promise<void> => {
@@ -187,11 +192,11 @@ const prepareEnvironment = async (
 export const createStorefront = async (argv: Arguments<StoreCreate>) => {
   await checkPnpmPresence('react-storefront project');
 
-  const { name, commit } = argv;
+  const { name, repository, branch } = argv;
 
   const spinner = ora('Downloading...').start();
   const target = await getFolderName(sanitize(name));
-  await downloadFromGitHub(Config.SaleorStorefrontRepo, target, commit);
+  await downloadFromGitHub(repository, target, branch);
 
   process.chdir(target);
   spinner.text = 'Creating .env...';

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,9 +1,9 @@
 export const TelemetryDomain = 'https://telemetry.saleor.io';
 
 export const SaleorStorefrontRepo = 'saleor/react-storefront';
-export const SaleorStorefrontHash = 'a5caa3f2580ad075faeee9d4a2125e77bc60f6d8';
+export const SaleorStorefrontDefaultBranch = 'main';
 
-export const SaleorAppHash = '1e3de9d775f2715d988c4ef90aee9101ea30fb16';
+export const SaleorAppDefaultBranch = 'main';
 export const SaleorAppRepo = 'saleor/saleor-app-template';
 
 export default TelemetryDomain;

--- a/src/lib/download.ts
+++ b/src/lib/download.ts
@@ -1,10 +1,20 @@
 import fs from 'fs-extra';
 import got from 'got';
+import { simpleGit } from 'simple-git';
 import stream from 'stream';
 import tar from 'tar';
 import { promisify } from 'util';
 
 const pipeline = promisify(stream.pipeline);
+const git = simpleGit();
+
+export const gitCopy = async (repo: string, dest: string, ref = 'main') => {
+  await git.clone(`https://github.com/${repo}`, dest, {
+    '--branch': ref,
+    '--depth': 1,
+  });
+  await fs.remove(`${dest}/.git`);
+};
 
 /* eslint-disable import/prefer-default-export */
 export const downloadFromGitHub = async (

--- a/src/lib/download.ts
+++ b/src/lib/download.ts
@@ -1,41 +1,18 @@
 import fs from 'fs-extra';
-import got from 'got';
+import GitURLParse from 'git-url-parse';
 import { simpleGit } from 'simple-git';
-import stream from 'stream';
-import tar from 'tar';
-import { promisify } from 'util';
 
-const pipeline = promisify(stream.pipeline);
+import { WrongGitURLError } from './util';
+
 const git = simpleGit();
 
-export const gitCopy = async (repo: string, dest: string, ref = 'main') => {
-  await git.clone(`https://github.com/${repo}`, dest, {
-    '--branch': ref,
-    '--depth': 1,
-  });
-  await fs.remove(`${dest}/.git`);
-};
-
 /* eslint-disable import/prefer-default-export */
-export const downloadFromGitHub = async (
-  repo: string,
-  dest: string,
-  source = 'master'
-) => {
-  const url = `https://github.com/${repo}/archive/${source}.tar.gz`;
-  const downloadStream = got.stream(url);
-  const filePath = `./${source}.tgz`;
-  const fileWriterStream = fs.createWriteStream(filePath, { mode: 0o755 });
-
+export const gitCopy = async (repo: string, dest: string, ref = 'main') => {
   try {
-    await pipeline(downloadStream, fileWriterStream);
-
-    await fs.ensureDir(dest);
-    await tar.x({ file: filePath, cwd: dest, strip: 1 });
-    await fs.remove(filePath);
+    const { href: repoURL } = GitURLParse(repo);
+    await git.clone(repoURL, dest, { '--branch': ref, '--depth': 1 });
+    await fs.remove(`${dest}/.git`);
   } catch (error) {
-    console.error(`Something went wrong. ${error}`);
+    throw new WrongGitURLError(`Provided Git URL is invalid: ${repo}`);
   }
-
-  fs.remove(filePath);
 };

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -41,6 +41,13 @@ export class NotSaleorAppDirectoryError extends Error {
   }
 }
 
+export class WrongGitURLError extends Error {
+  constructor(message = '') {
+    super(message);
+    this.name = 'WrongGitURLError';
+  }
+}
+
 export class SaleorAppInstallError extends Error {
   constructor(message = '') {
     super(message);

--- a/src/types.ts
+++ b/src/types.ts
@@ -61,7 +61,7 @@ export interface StoreCreate extends BaseOptions {
   name: string;
   auto?: boolean;
   environment?: string;
-  repository: string;
+  template: string;
   branch?: string;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -61,7 +61,8 @@ export interface StoreCreate extends BaseOptions {
   name: string;
   auto?: boolean;
   environment?: string;
-  commit?: string;
+  repository: string;
+  branch?: string;
 }
 
 export interface StoreDeploy extends BaseOptions {


### PR DESCRIPTION
## I want to merge this PR because 

- it aligns the `* create` with how Git clone work; thus, it's only possible to specify a branch or a tag of a Git repository
- it adds `--template` (aliased with`-t`) to specify custom GitHub repo. 

## Related (issues, PRs, topics)

- #430 
- #449 

## Steps to test feature

- `app create`
- `app create --branch <branch name>`
- `app create --branch <tag name>`
- `app create --template saleor/saleor-app-template --branch add-typings`

## I have:

- [x] Tested it locally and it doesn't break existing features
- [ ] Added documentation if public changes are introduced
- [ ] Added tests for my code

## Next Steps

- detect if given repo is a Saleor App template
