### PR TITLE
Allow `app permissions` to run non interactive

### DIFF
--- a/docs/app.md
+++ b/docs/app.md
@@ -116,9 +116,23 @@ Options:
 Add or remove permission for a Saleor App
 
 Options:
-      --json     Output the data as JSON                               [boolean]
-  -V, --version  Show version number                                   [boolean]
-  -h, --help     Show help                                             [boolean]
+      --json             Output the data as JSON                       [boolean]
+  -u, --instance, --url                                                 [string]
+      --app-id           The Saleor App id                              [string]
+      --permissions      The array of permissions                        [array]
+  -V, --version          Show version number                           [boolean]
+  -h, --help             Show help                                     [boolean]
+```
+
+Example usage in non-interactive mode
+
+```
+saleor app permission \
+  --organization=organization-slug \
+  --environment=env-id-or-name \
+  --app-id=APP-ID \
+  --permissions=MANAGE_USERS \
+  --permissions=MANAGE_STAFF
 ```
 
 ### saleor app deploy

--- a/src/cli/app/token.ts
+++ b/src/cli/app/token.ts
@@ -84,7 +84,10 @@ export const createAppToken = async (url: string, app: string) => {
   return authToken;
 };
 
-export const getSaleorApp = async (endpoint: string) => {
+export const getSaleorApp = async (
+  endpoint: string,
+  appId: string | undefined = undefined
+) => {
   const headers = await Config.getBearerHeader();
 
   debug('Fetching Saleor Apps');
@@ -99,6 +102,11 @@ export const getSaleorApp = async (endpoint: string) => {
     .json();
 
   const apps = getAppsFromResult(data);
+
+  // return early if appId have been provided and it's found in apps
+  if (apps.map(({ node }: any) => node.id).includes(appId)) {
+    return { app: appId, apps };
+  }
 
   const choices = apps.map(({ node }: any) => ({
     name: node.name,

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,6 +32,8 @@ export interface Options extends BaseOptions {
   registerUrl?: string;
   saleorApiUrl?: string;
   githubPrompt?: boolean;
+  appId?: string;
+  permissions?: string[];
 }
 
 export interface CreatePromptResult {


### PR DESCRIPTION
## I want to merge this PR because 

- 

## Related (issues, PRs, topics)

- https://github.com/saleor/saleor-cli/issues/352

## Steps to test feature

- `saleor app permission --environment=env --app-id=app --permissions=MANAGE_USERS --permissions=MANAGE_STAFF`

## I have:

- [x] Tested it locally and it doesn't break existing features
- [x] Added documentation if public changes are introduced
- [ ] Added tests for my code
