### PR TITLE
Remove cache for tests-nightly

### DIFF
--- a/.github/workflows/tests-nightly.yml
+++ b/.github/workflows/tests-nightly.yml
@@ -1,6 +1,7 @@
 name: Execute nightly tests
 
 on:
+  workflow_dispatch:
   schedule:
     - cron: '0 6 * * 1-5'
 
@@ -13,34 +14,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Install Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: 16
-
+      - uses: actions/checkout@v3
       - uses: pnpm/action-setup@v2.2.2
-        name: Install pnpm
-        id: pnpm-install
         with:
           version: 7.5.0
-          run_install: false
-
-      - name: Get pnpm store directory
-        id: pnpm-cache
-        run: |
-          echo "::set-output name=pnpm_cache_dir::$(pnpm store path)"
-
-      - uses: actions/cache@v3
-        name: Setup pnpm cache
+      - uses: actions/setup-node@v3
         with:
-          path: ${{ steps.pnpm-cache.outputs.pnpm_cache_dir }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-store-
-
+          node-version: 16.x
+          cache: 'pnpm'
       - name: Install dependencies
         run: pnpm install
 


### PR DESCRIPTION
## I want to merge this PR because 

- it removes the pnpm cache as it stales the installation process for all actions 

## Related (issues, PRs, topics)

- NA

## Steps to test feature

- NA

## I have:

- [ ] Tested it locally and it doesn't break existing features
- [ ] Added documentation if public changes are introduced
- [ ] Added tests for my code
