### PR TITLE
Enable JSON output for more commands

### DIFF
--- a/src/cli/backup/create.ts
+++ b/src/cli/backup/create.ts
@@ -36,5 +36,5 @@ export const handler = async (argv: Arguments<any>) => {
     `Creating backup ${name}`,
     'Yay! Backup created!'
   );
-  showResult(result);
+  showResult(result, argv);
 };

--- a/src/cli/backup/list.ts
+++ b/src/cli/backup/list.ts
@@ -26,6 +26,11 @@ export const handler = async (argv: Arguments<Options>) => {
 
   verifyResultLength(result, 'backup');
 
+  if (argv.json) {
+    console.log(JSON.stringify(result, null, 2));
+    return;
+  }
+
   cli.table(result, {
     name: {
       header: 'Backup',

--- a/src/cli/env/list.ts
+++ b/src/cli/env/list.ts
@@ -37,6 +37,11 @@ export const handler = async (argv: Arguments) => {
 
   verifyResultLength(result, 'environment');
 
+  if (argv.json) {
+    console.log(JSON.stringify(result, null, 2));
+    return;
+  }
+
   cli.table(
     result,
     {

--- a/src/cli/env/promote.ts
+++ b/src/cli/env/promote.ts
@@ -33,7 +33,7 @@ export const handler = async (argv: Arguments<Options>) => {
   const result = (await PUT(API.UpgradeEnvironment, argv, {
     json: { service: service.value },
   })) as any;
-  showResult(result);
+  showResult(result, argv);
 };
 
 const getService = async (argv: Arguments<Options>) => {

--- a/src/cli/job/list.ts
+++ b/src/cli/job/list.ts
@@ -29,6 +29,11 @@ export const handler = async (argv: Arguments<Options>) => {
   debug('command arguments: %O', obfuscateArgv(argv));
   const result = (await GET(API.Job, argv)) as any[];
 
+  if (argv.json) {
+    console.log(JSON.stringify(result, null, 2));
+    return;
+  }
+
   cli.table(result, {
     type: {
       header: 'Type',

--- a/src/cli/organization/list.ts
+++ b/src/cli/organization/list.ts
@@ -24,6 +24,11 @@ export const handler = async (argv: Arguments<Options>) => {
 
   verifyResultLength(result, 'organization');
 
+  if (argv.json) {
+    console.log(JSON.stringify(result, null, 2));
+    return;
+  }
+
   cli.table(result, {
     slug: { minWidth: 2 },
     name: { minWidth: 2 },

--- a/src/cli/organization/permissions.ts
+++ b/src/cli/organization/permissions.ts
@@ -26,7 +26,7 @@ export const handler = async (argv: Arguments<Options>) => {
     ...{ organization: argv.slug || argv.organization },
   })) as any;
 
-  showResult(result);
+  showResult(result, argv);
 };
 
 export const middlewares = [useOrganization];

--- a/src/cli/project/list.ts
+++ b/src/cli/project/list.ts
@@ -18,6 +18,11 @@ export const handler = async (argv: Arguments<Options>) => {
   debug('command arguments: %O', obfuscateArgv(argv));
   const result = (await GET(API.Project, argv)) as any[];
 
+  if (argv.json) {
+    console.log(JSON.stringify(result, null, 2));
+    return;
+  }
+
   cli.table(result, {
     slug: { minWidth: 2 },
     name: { minWidth: 2, get: ({ name }) => chalk.cyan(name) },

--- a/src/cli/project/remove.ts
+++ b/src/cli/project/remove.ts
@@ -22,7 +22,7 @@ export const builder: CommandBuilder = (_) =>
     desc: 'slug of the project',
   }).option('force', {
     type: 'boolean',
-    desc: 'skip confrimation prompt',
+    desc: 'skip confirmation prompt',
   });
 
 export const handler = async (argv: Arguments<Options>) => {
@@ -36,7 +36,7 @@ export const handler = async (argv: Arguments<Options>) => {
     (await DELETE(API.Project, { ...argv, project: project.value })) as any;
     console.log(
       chalk.green('✔'),
-      chalk.bold('Project has been successfuly removed')
+      chalk.bold('Project has been successfully removed')
     );
   }
 };

--- a/src/cli/webhook/list.ts
+++ b/src/cli/webhook/list.ts
@@ -51,6 +51,11 @@ export const handler = async (argv: Arguments<Options>) => {
     process.exit(0);
   }
 
+  if (argv.json) {
+    console.log(JSON.stringify(webhookList, null, 2));
+    return;
+  }
+
   for (const {
     node: { name: appName, webhooks },
   } of apps) {


### PR DESCRIPTION
## I want to merge this PR because 

- it enables JSON output for more commands

## Related (issues, PRs, topics)

- NA

## Steps to test feature

- `saleor backup create --json`
- `saleor backup list --json`
- `saleor env list --json`
- `saleor env promote --json`
- `saleor job list --json`
- `saleor organization list --json`
- `saleor organization permissions --json`
- `saleor project list --json`
- `saleor webhook list --json`

## I have:

- [x] Tested it locally and it doesn't break existing features
- [ ] Added documentation if public changes are introduced
- [ ] Added tests for my code
