### PR TITLE
Add APL=vercel env variable when deploying app

### DIFF
--- a/src/cli/app/deploy.ts
+++ b/src/cli/app/deploy.ts
@@ -132,6 +132,12 @@ export const handler = async (argv: Arguments<Options>) => {
       target: ['production', 'preview'],
       type: 'plain',
     },
+    {
+      key: 'APL',
+      value: 'vercel',
+      target: ['production', 'preview'],
+      type: 'plain',
+    },
   ]);
 
   debug(`Triggering deployment in Vercel for ${name} with ID: ${projectId}`);


### PR DESCRIPTION
## I want to merge this PR because 

Saleor apps, especially template is looking for `APL` env variable. Locally it can be set but in vercel it must be `APL=vercel`

https://github.com/saleor/saleor-app-template/blob/canary/saleor-app.ts

## Related (issues, PRs, topics)

- 

## Steps to test feature

- 

## I have:

- [ ] Tested it locally and it doesn't break existing features
- [ ] Added documentation if public changes are introduced
- [ ] Added tests for my code
