### PR TITLE
Additional workflows for GitHub Actions

### DIFF
--- a/.github/workflows/clear-staging-cloud.yml
+++ b/.github/workflows/clear-staging-cloud.yml
@@ -1,0 +1,45 @@
+name: Clear staging cloud projects
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 7 * * 1-7'
+
+  repository_dispatch:
+    types: [automation-tests-event]
+
+jobs:
+  run-functional-tests:
+    if: ${{ github.event_name != 'repository_dispatch' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v3
+      - uses: pnpm/action-setup@v2.2.2
+        with:
+          version: 7.5.0
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16.x
+          cache: 'pnpm'
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Prepare saleor CLI
+        run: pnpm build
+
+      - name: Write config file
+        id: write-config-file
+        env:
+          CLI_ACCESS_TOKEN: ${{ secrets.CLI_ACCESS_TOKEN }}
+          CLI_GITHUB_TOKEN: ${{ secrets.CLI_GITHUB_TOKEN }}
+          CLI_VERCEL_TOKEN: ${{ secrets.CLI_VERCEL_TOKEN }}
+          TEST_COMMAND: 'node dist/saleor.js'
+        run: echo '{"token":"${{ secrets.CLI_ACCESS_TOKEN }}","telemetry":"false", "github_token":"${{ secrets.CLI_GITHUB_TOKEN }}", "vercel_token":"${{ secrets.CLI_VERCEL_TOKEN }}"  }' > ~/.config/saleor.json
+
+      - name: clear cloud projects
+        env:
+          SALEOR_CLI_ENV: staging
+          RUN_FUNCTIONAL_TESTS: true
+        run: |
+          pnpm vitest run test/clear_cloud.test.ts

--- a/.github/workflows/deployment-tests-nightly.yml
+++ b/.github/workflows/deployment-tests-nightly.yml
@@ -1,0 +1,57 @@
+name: Execute nightly deployment tests
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 4 * * 1-7'
+
+  repository_dispatch:
+    types: [automation-tests-event]
+
+jobs:
+  run-functional-tests:
+    if: ${{ github.event_name != 'repository_dispatch' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v3
+      - uses: pnpm/action-setup@v2.2.2
+        with:
+          version: 7.5.0
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16.x
+          cache: 'pnpm'
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Prepare saleor CLI
+        run: pnpm build
+
+      - name: Write config file
+        id: write-config-file
+        env:
+          CLI_ACCESS_TOKEN: ${{ secrets.CLI_ACCESS_TOKEN }}
+          CLI_GITHUB_TOKEN: ${{ secrets.CLI_GITHUB_TOKEN }}
+          CLI_VERCEL_TOKEN: ${{ secrets.CLI_VERCEL_TOKEN }}
+          TEST_COMMAND: 'node dist/saleor.js'
+        run: echo '{"token":"${{ secrets.CLI_ACCESS_TOKEN }}","telemetry":"false", "github_token":"${{ secrets.CLI_GITHUB_TOKEN }}", "vercel_token":"${{ secrets.CLI_VERCEL_TOKEN }}"  }' > ~/.config/saleor.json
+
+      - name: pre run
+        env:
+          SALEOR_CLI_ENV: staging
+          RUN_FUNCTIONAL_TESTS: true
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: |
+          node dist/saleor.js info
+          node dist/saleor.js status
+
+      - name: run tests
+        env:
+          SALEOR_CLI_ENV: staging
+          RUN_FUNCTIONAL_TESTS: true
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: |
+          git config --global user.name 'GA-saleor-cli'
+          git config --global user.email 'GA-saleor-cli@users.noreply.github.com'
+          pnpm vitest test/functional -t 'deploy' --no-threads

--- a/test/functional/checkout/deploy.test.ts
+++ b/test/functional/checkout/deploy.test.ts
@@ -47,9 +47,12 @@ describe('checkout deploy', async () => {
         `--environment=${testEnvironmentName}`,
         `--organization=${testOrganization}`,
       ];
-      const { exitCode } = await trigger(command, params, {
+      const { exitCode, output, err } = await trigger(command, params, {
         cwd: storefrontCwd,
       });
+
+      console.log('output', output);
+      console.log('err', err);
 
       expect(exitCode).toBe(0);
     },

--- a/test/functional/storefront/deploy.test.ts
+++ b/test/functional/storefront/deploy.test.ts
@@ -58,9 +58,12 @@ describe('storefront deploy', async () => {
         `--environment=${testEnvironmentName}`,
         `--organization=${testOrganization}`,
       ];
-      const { exitCode } = await trigger(command, params, {
+      const { exitCode, output, err } = await trigger(command, params, {
         cwd: storefrontCwd,
       });
+
+      console.log('output', output);
+      console.log('err', err);
 
       expect(exitCode).toBe(0);
     },


### PR DESCRIPTION
## I want to merge this PR because 

It introduces additional workflows for nightly tests
- deployment-tests-nightly to run tests for deployment commands (`app deploy`, `checkout deploy`, `storefront deploy`
- clear-staging-cloud to remove all projects (including environments)

## Related (issues, PRs, topics)

- #436 

## Steps to test feature

- 

## I have:

- [ ] Tested it locally and it doesn't break existing features
- [ ] Added documentation if public changes are introduced
- [ ] Added tests for my code
