### PR TITLE
Kill subprocesses for tunnel test

### DIFF
--- a/.github/workflows/clear-staging-cloud.yml
+++ b/.github/workflows/clear-staging-cloud.yml
@@ -3,7 +3,7 @@ name: Clear staging cloud projects
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 7 * * 1-7'
+    - cron: '0 7 * * 0-6'
 
   repository_dispatch:
     types: [automation-tests-event]

--- a/.github/workflows/deployment-tests-nightly.yml
+++ b/.github/workflows/deployment-tests-nightly.yml
@@ -3,7 +3,7 @@ name: Execute nightly deployment tests
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 4 * * 1-7'
+    - cron: '0 4 * * 0-6'
 
   repository_dispatch:
     types: [automation-tests-event]

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "pkg": "^5.8.0",
     "prettier": "2.7.1",
     "release-it": "^15.5.0",
+    "rimraf": "^3.0.2",
     "tsm": "^2.2.2",
     "typescript": "4.8.4",
     "vitest": "^0.24.3"

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "pkg": "^5.8.0",
     "prettier": "2.7.1",
     "release-it": "^15.5.0",
-    "rimraf": "^3.0.2",
+    "tree-kill": "^1.2.2",
     "tsm": "^2.2.2",
     "typescript": "4.8.4",
     "vitest": "^0.24.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,13 +62,13 @@ specifiers:
   release-it: ^15.5.0
   replace-in-file: ^6.3.5
   retes: ^0.34.0
-  rimraf: ^3.0.2
   sanitize-filename: ^1.6.3
   semver: ^7.3.8
   simple-git: ^3.14.1
   slugify: ^1.6.5
   tar: ^6.1.11
   tplv: ^1.0.0
+  tree-kill: ^1.2.2
   tsm: ^2.2.2
   typescript: 4.8.4
   vitest: ^0.24.3
@@ -144,7 +144,7 @@ devDependencies:
   pkg: 5.8.0
   prettier: 2.7.1
   release-it: 15.5.0
-  rimraf: 3.0.2
+  tree-kill: 1.2.2
   tsm: 2.2.2
   typescript: 4.8.4
   vitest: 0.24.3
@@ -7430,6 +7430,11 @@ packages:
 
   /tr46/0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
+  /tree-kill/1.2.2:
+    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
+    hasBin: true
+    dev: true
 
   /truncate-utf8-bytes/1.0.2:
     resolution: {integrity: sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,7 @@ specifiers:
   release-it: ^15.5.0
   replace-in-file: ^6.3.5
   retes: ^0.34.0
+  rimraf: ^3.0.2
   sanitize-filename: ^1.6.3
   semver: ^7.3.8
   simple-git: ^3.14.1
@@ -143,6 +144,7 @@ devDependencies:
   pkg: 5.8.0
   prettier: 2.7.1
   release-it: 15.5.0
+  rimraf: 3.0.2
   tsm: 2.2.2
   typescript: 4.8.4
   vitest: 0.24.3

--- a/test/functional/tunnel.test.ts
+++ b/test/functional/tunnel.test.ts
@@ -1,7 +1,6 @@
 import { spawn } from 'child_process';
-import fs from 'fs-extra';
 import got from 'got';
-import path from 'path';
+import rimraf from 'rimraf';
 import { afterAll, beforeAll, expect, it } from 'vitest';
 
 import { Manifest } from '../../src/lib/common';
@@ -27,7 +26,8 @@ beforeAll(async () => {
 }, 1000 * 60 * 10);
 
 afterAll(async () => {
-  await fs.remove(path.join(process.cwd(), appCwd));
+  console.log(appCwd);
+  await rimraf(appCwd, () => console.log(`removed ${appCwd}`));
 });
 
 it(
@@ -76,13 +76,16 @@ it(
     await delay(1000 * 60 * 2);
     console.log('closing');
     tunnel.emit('close');
+    tunnel.kill();
     app.emit('close');
+    app.kill();
   },
   1000 * 60 * 3
 );
 
 const checkTunnelUrl = async (tunnelUrl: string) => {
-  const { statusCode } = await got.get(tunnelUrl[0]);
+  console.log('tunnelUrl', tunnelUrl);
+  const { statusCode } = await got.get(tunnelUrl);
   expect(statusCode).toBe(200);
 };
 


### PR DESCRIPTION
## I want to merge this PR because 

- It kills the spawned subprocesses with tunnel command. Hence all the processes which were stared are closed and the created app -> `tunnel-app` can be deleted

## Related (issues, PRs, topics)

- #451 

## Steps to test feature

- `RUN_FUNCTIONAL_TESTS=true pnpm vitest run  test/functional/tunnel.test.ts `

## I have:

- [ ] Tested it locally and it doesn't break existing features
- [ ] Added documentation if public changes are introduced
- [ ] Added tests for my code
