### PR TITLE
Introduce `--example` flag for the `app create`

### DIFF
--- a/docs/app.md
+++ b/docs/app.md
@@ -70,12 +70,15 @@ Positionals:
   name                                       [string] [default: "my-saleor-app"]
 
 Options:
-      --json                  Output the data as JSON                  [boolean]
+      --json                            Output the data as JSON        [boolean]
   -u, --instance, --url                                                 [string]
       --dependencies, --deps                           [boolean] [default: true]
-  -V, --version               Show version number                      [boolean]
-  -h, --help                  Show help                                [boolean]
-```
+  -t, --template, --repo, --repository
+                                [string] [default: "saleor/saleor-app-template"]
+  -b, --branch                                        [string] [default: "main"]
+  -e, --example                                                         [string]
+  -V, --version                         Show version number            [boolean]
+  -h, --help                            Show help                      [boolean]
 
 ### saleor app tunnel
 

--- a/src/lib/download.ts
+++ b/src/lib/download.ts
@@ -1,5 +1,6 @@
 import fs from 'fs-extra';
 import GitURLParse from 'git-url-parse';
+import { join } from 'path';
 import { simpleGit } from 'simple-git';
 
 import { WrongGitURLError } from './util';
@@ -11,6 +12,19 @@ export const gitCopy = async (repo: string, dest: string, ref = 'main') => {
   try {
     const { href: repoURL } = GitURLParse(repo);
     await git.clone(repoURL, dest, { '--branch': ref, '--depth': 1 });
+    await fs.remove(`${dest}/.git`);
+  } catch (error) {
+    throw new WrongGitURLError(`Provided Git URL is invalid: ${repo}`);
+  }
+};
+
+export const gitCopySha = async (repo: string, dest: string, sha: string) => {
+  try {
+    const { href: repoURL } = GitURLParse(repo);
+    await git.clone(repoURL, dest).cwd({ path: dest });
+    const target = join(process.cwd(), dest);
+    await git.cwd({ path: target, root: true });
+    await git.reset(['--hard', sha]);
     await fs.remove(`${dest}/.git`);
   } catch (error) {
     throw new WrongGitURLError(`Provided Git URL is invalid: ${repo}`);

--- a/src/lib/download.ts
+++ b/src/lib/download.ts
@@ -18,7 +18,7 @@ export const gitCopy = async (repo: string, dest: string, ref = 'main') => {
   }
 };
 
-export const gitCopySha = async (repo: string, dest: string, sha: string) => {
+export const gitCopySHA = async (repo: string, dest: string, sha: string) => {
   try {
     const { href: repoURL } = GitURLParse(repo);
     await git.clone(repoURL, dest).cwd({ path: dest });

--- a/src/types.ts
+++ b/src/types.ts
@@ -65,6 +65,7 @@ export interface StoreCreate extends BaseOptions {
   environment?: string;
   template: string;
   branch?: string;
+  example?: string;
 }
 
 export interface StoreDeploy extends BaseOptions {


### PR DESCRIPTION
## I want to merge this PR because 

- it introduces the `--example` arg for the `app create` command. It allows to choose the example repository from [app-examples](https://github.com/saleor/app-examples) as the app template

## Related (issues, PRs, topics)

- #489 

## Steps to test feature

- saleor app create --example
- saleor app create --example external-webhook 

## I have:

- [x] Tested it locally and it doesn't break existing features
- [x] Added documentation if public changes are introduced
- [ ] Added tests for my code
