### PR TITLE
Make telemetry call non-block middleware stack

### DIFF
--- a/src/middleware/index.ts
+++ b/src/middleware/index.ts
@@ -417,19 +417,20 @@ export const useTelemetry = (version: string) => async (argv: Arguments) => {
   if (isTelemetryEnabled) {
     debug('telemetry', argv._);
 
-    try {
-      await got.post(Configuration.TelemetryDomain, {
+    got
+      .post(Configuration.TelemetryDomain, {
         json: { command, environment, version, user_session: userSession },
         timeout: {
           request: 2000,
         },
+      })
+      .catch((error) => {
+        if (error instanceof HTTPError) {
+          console.warn(`${chalk.yellow('Warning')} Telemetry is down `);
+        }
+
+        // FIXME notify Sentry
       });
-    } catch (error) {
-      if (error instanceof HTTPError) {
-        console.error(`${chalk.yellow('Warning')} Telemetry is down `);
-      }
-      // FIXME notify Sentry
-    }
   }
 };
 


### PR DESCRIPTION
As initially proposed by @2can and proved by @lkostrowski :)

## I want to merge this PR because 

- it makes the telemetry call non-blocking the middleware stack, yet the potential errors are still handled

## Related (issues, PRs, topics)

- #502 

## Steps to test feature

- NA

## I have:

- [x] Tested it locally and it doesn't break existing features
- [ ] Added documentation if public changes are introduced
- [ ] Added tests for my code
