### PR TITLE
Use toLowerCase for domain

### DIFF
--- a/src/cli/env/create.ts
+++ b/src/cli/env/create.ts
@@ -284,7 +284,8 @@ const getDomain = async (
     type: 'input',
     name: 'domain',
     message: 'Environment domain',
-    initial: initial || slugify(argv.domain || argv.name || name || ''),
+    initial:
+      initial || slugify(argv.domain || argv.name || name || '').toLowerCase(),
     required: true,
     skip: !!argv.domain,
     validate: (value) => {


### PR DESCRIPTION
## I want to merge this PR because 

- it makes the domain slugify lowercase. The API requires the domain to be lowercase, hence the change should prevent  the `Label is invalid` error 

## Related (issues, PRs, topics)

- 

## Steps to test feature

- 

## I have:

- [x] Tested it locally and it doesn't break existing features
- [ ] Added documentation if public changes are introduced
- [ ] Added tests for my code
