### PR TITLE
Rename key to backup in Backup endpoint

### DIFF
--- a/docs/backup.md
+++ b/docs/backup.md
@@ -55,7 +55,7 @@ Options:
 ### saleor backup show
 
 ```
-saleor backup show [key]
+saleor backup show [backup|backup-key]
 
 Show a specific backup
 

--- a/src/cli/backup/show.ts
+++ b/src/cli/backup/show.ts
@@ -7,7 +7,7 @@ import { Options } from '../../types.js';
 
 const debug = Debug('saleor-cli:backup:show');
 
-export const command = 'show [key]';
+export const command = 'show [backup|backup-key]';
 export const desc = 'Show a specific backup';
 
 export const builder: CommandBuilder = NoCommandBuilderSetup;

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -92,7 +92,7 @@ export const API: Record<string, DefaultURLPath> = {
   TaskStatus: (_) => `service/task-status/${_.task}`,
   Backup: (_) =>
     `organizations/${_.organization}/environments/${_.environment}/backups/${
-      _.key || ''
+      _.backup || ''
     }`,
   Restore: (_) =>
     `organizations/${_.organization}/environments/${_.environment}/restore`,


### PR DESCRIPTION
## I want to merge this PR because 

- It renames `key` to `backup` in the API's Backup endpoint. This fixes the interference of `key` keyword with environment.

## Related (issues, PRs, topics)

- #477 

## Steps to test feature

- `saleor backup list ENVIRONMENT_KEY`

## I have:

- [x] Tested it locally and it doesn't break existing features
- [x] Added documentation if public changes are introduced
- [ ] Added tests for my code
