### PR TITLE
Eliminate direct calls for API endpoint

### DIFF
--- a/src/cli/app/permission.ts
+++ b/src/cli/app/permission.ts
@@ -7,13 +7,8 @@ import { Arguments, CommandBuilder } from 'yargs';
 
 import { AppUpdate, GetPermissionEnum } from '../../generated/graphql.js';
 import { Config } from '../../lib/config.js';
-import { getEnvironmentGraphqlEndpoint } from '../../lib/environment.js';
 import { obfuscateArgv, printContext, println } from '../../lib/util.js';
-import {
-  useEnvironment,
-  useOrganization,
-  useToken,
-} from '../../middleware/index.js';
+import { useAppConfig, useInstanceConnector } from '../../middleware/index.js';
 import { Options } from '../../types.js';
 import { getSaleorApp } from './token.js';
 
@@ -40,7 +35,8 @@ export const handler = async (argv: Arguments<Options>) => {
 
   printContext(organization, environment);
 
-  const endpoint = await getEnvironmentGraphqlEndpoint(argv);
+  const { instance } = argv;
+  const endpoint = `${instance}/graphql/`;
   debug(`Saleor endpoint: ${endpoint}`);
 
   const { app, apps } = await getSaleorApp(endpoint, argv.appId);
@@ -115,4 +111,4 @@ const getPermissions = async (
   return permissions;
 };
 
-export const middlewares = [useToken, useOrganization, useEnvironment];
+export const middlewares = [useAppConfig, useInstanceConnector];

--- a/src/cli/app/token.ts
+++ b/src/cli/app/token.ts
@@ -7,18 +7,13 @@ import { Arguments, CommandBuilder } from 'yargs';
 import { AppTokenCreate } from '../../generated/graphql.js';
 import { SaleorAppList } from '../../graphql/SaleorAppList.js';
 import { Config } from '../../lib/config.js';
-import { getEnvironmentGraphqlEndpoint } from '../../lib/environment.js';
 import {
   contentBox,
   getAppsFromResult,
   obfuscateArgv,
   printContext,
 } from '../../lib/util.js';
-import {
-  useEnvironment,
-  useOrganization,
-  useToken,
-} from '../../middleware/index.js';
+import { useAppConfig, useInstanceConnector } from '../../middleware/index.js';
 import { Options } from '../../types.js';
 
 const debug = Debug('saleor-cli:app:token');
@@ -40,7 +35,8 @@ export const handler = async (argv: Arguments<Options>) => {
 
   printContext(organization, environment);
 
-  const endpoint = await getEnvironmentGraphqlEndpoint(argv);
+  const { instance } = argv;
+  const endpoint = `${instance}/graphql/`;
   debug(`Saleor endpoint: ${endpoint}`);
 
   let appId: string;
@@ -124,4 +120,4 @@ export const getSaleorApp = async (
   return { app, apps };
 };
 
-export const middlewares = [useToken, useOrganization, useEnvironment];
+export const middlewares = [useAppConfig, useInstanceConnector];

--- a/src/cli/backup/index.ts
+++ b/src/cli/backup/index.ts
@@ -1,8 +1,4 @@
-import {
-  useEnvironment,
-  useOrganization,
-  useToken,
-} from '../../middleware/index.js';
+import { useAppConfig, useInstanceConnector } from '../../middleware/index.js';
 import * as create from './create.js';
 import * as list from './list.js';
 import * as remove from './remove.js';
@@ -11,6 +7,6 @@ import * as show from './show.js';
 
 export default function (_: any) {
   _.command([list, create, show, remove, restore])
-    .middleware([useToken, useOrganization, useEnvironment])
+    .middleware([useAppConfig, useInstanceConnector])
     .demandCommand(1, 'You need at least one command before moving on');
 }

--- a/src/cli/backup/restore.ts
+++ b/src/cli/backup/restore.ts
@@ -2,7 +2,6 @@ import Debug from 'debug';
 import Enquirer from 'enquirer';
 import type { Arguments, CommandBuilder } from 'yargs';
 
-import { getEnvironmentGraphqlEndpoint } from '../../lib/environment.js';
 import { API, PUT } from '../../lib/index.js';
 import {
   obfuscateArgv,
@@ -55,7 +54,8 @@ export const handler = async (argv: Arguments<Options>) => {
   });
 
   if (update) {
-    const endpoint = await getEnvironmentGraphqlEndpoint(argv);
+    const { instance } = argv;
+    const endpoint = `${instance}/graphql/`;
     debug(`Saleor endpoint: ${endpoint}`);
     await updateWebhook(endpoint);
   }

--- a/src/cli/trigger.ts
+++ b/src/cli/trigger.ts
@@ -6,14 +6,9 @@ import type { Arguments, CommandBuilder } from 'yargs';
 
 import * as SaleorGraphQL from '../generated/graphql.js';
 import { Config } from '../lib/config.js';
-import { getEnvironmentGraphqlEndpoint } from '../lib/environment.js';
 import { DefaultSaleorEndpoint } from '../lib/index.js';
 import { capitalize, obfuscateArgv } from '../lib/util.js';
-import {
-  useEnvironment,
-  useOrganization,
-  useToken,
-} from '../middleware/index.js';
+import { useAppConfig, useInstanceConnector } from '../middleware/index.js';
 import { Options } from '../types.js';
 
 const debug = Debug('saleor-cli:trigger');
@@ -67,7 +62,8 @@ export const handler = async (argv: Arguments<Options>) => {
     `\n  GraphQL Operation for ${chalk.underline(event)} available\n`
   );
 
-  const endpoint = await getEnvironmentGraphqlEndpoint(argv);
+  const { instance } = argv;
+  const endpoint = `${instance}/graphql/`;
   const headers = await Config.getBearerHeader();
 
   // FIXME
@@ -99,4 +95,4 @@ export const handler = async (argv: Arguments<Options>) => {
   process.exit(0);
 };
 
-export const middlewares = [useToken, useOrganization, useEnvironment];
+export const middlewares = [useAppConfig, useInstanceConnector];

--- a/src/cli/webhook/create.ts
+++ b/src/cli/webhook/create.ts
@@ -11,7 +11,6 @@ import {
 } from '../../generated/graphql.js';
 import { doWebhookCreate } from '../../graphql/doWebhookCreate.js';
 import { Config } from '../../lib/config.js';
-import { getEnvironmentGraphqlEndpoint } from '../../lib/environment.js';
 import { DefaultSaleorEndpoint } from '../../lib/index.js';
 import { obfuscateArgv, without } from '../../lib/util.js';
 import { interactiveSaleorApp } from '../../middleware/index.js';
@@ -107,7 +106,8 @@ export const handler = async (argv: Arguments<Options>) => {
     },
   ]);
 
-  const endpoint = await getEnvironmentGraphqlEndpoint(argv);
+  const { instance } = argv;
+  const endpoint = `${instance}/graphql/`;
   const headers = await Config.getBearerHeader();
 
   const { data }: any = await got

--- a/src/cli/webhook/edit.ts
+++ b/src/cli/webhook/edit.ts
@@ -6,7 +6,6 @@ import type { Arguments } from 'yargs';
 
 import { doWebhookUpdate } from '../../graphql/doWebhookUpdate.js';
 import { Config } from '../../lib/config.js';
-import { getEnvironmentGraphqlEndpoint } from '../../lib/environment.js';
 import { NoCommandBuilderSetup } from '../../lib/index.js';
 import {
   obfuscateArgv,
@@ -28,8 +27,8 @@ export const builder = NoCommandBuilderSetup;
 
 export const handler = async (argv: Arguments<Options>) => {
   debug('command arguments: %O', obfuscateArgv(argv));
-  const { environment, webhookID } = argv;
-  const endpoint = await getEnvironmentGraphqlEndpoint(argv);
+  const { environment, webhookID, instance } = argv;
+  const endpoint = `${instance}/graphql/`;
   const headers = await Config.getBearerHeader();
 
   const query = `query getWebhook($id: ID!) {

--- a/src/cli/webhook/index.ts
+++ b/src/cli/webhook/index.ts
@@ -1,8 +1,4 @@
-import {
-  useEnvironment,
-  useOrganization,
-  useToken,
-} from '../../middleware/index.js';
+import { useAppConfig, useInstanceConnector } from '../../middleware/index.js';
 import * as create from './create.js';
 import * as edit from './edit.js';
 import * as list from './list.js';
@@ -10,6 +6,6 @@ import * as update from './update.js';
 
 export default function (_: any) {
   _.command([list, create, edit, update])
-    .middleware([useToken, useOrganization, useEnvironment])
+    .middleware([useAppConfig, useInstanceConnector])
     .demandCommand(1, 'You need at least one command before moving on');
 }

--- a/src/cli/webhook/list.ts
+++ b/src/cli/webhook/list.ts
@@ -6,7 +6,6 @@ import { Arguments } from 'yargs';
 
 import { WebhookList } from '../../graphql/WebhookList.js';
 import { Config } from '../../lib/config.js';
-import { getEnvironmentGraphqlEndpoint } from '../../lib/environment.js';
 import { getAppsFromResult, obfuscateArgv } from '../../lib/util.js';
 import { Options } from '../../types.js';
 
@@ -19,7 +18,8 @@ export const desc = 'List webhooks for an environment';
 
 export const handler = async (argv: Arguments<Options>) => {
   debug('command arguments: %O', obfuscateArgv(argv));
-  const endpoint = await getEnvironmentGraphqlEndpoint(argv);
+  const { instance } = argv;
+  const endpoint = `${instance}/graphql/`;
   const headers = await Config.getBearerHeader();
 
   const { data }: any = await got

--- a/src/cli/webhook/update.ts
+++ b/src/cli/webhook/update.ts
@@ -7,7 +7,6 @@ import { Arguments } from 'yargs';
 import { doWebhookUpdate } from '../../graphql/doWebhookUpdate.js';
 import { WebhookList } from '../../graphql/WebhookList.js';
 import { Config } from '../../lib/config.js';
-import { getEnvironmentGraphqlEndpoint } from '../../lib/environment.js';
 import { getAppsFromResult, obfuscateArgv } from '../../lib/util.js';
 import { Options } from '../../types.js';
 
@@ -18,7 +17,8 @@ export const desc = 'Update webhooks for an environment';
 
 export const handler = async (argv: Arguments<Options>) => {
   debug('command arguments: %O', obfuscateArgv(argv));
-  const endpoint = await getEnvironmentGraphqlEndpoint(argv);
+  const { instance } = argv;
+  const endpoint = `${instance}/graphql/`;
   await updateWebhook(endpoint);
 };
 

--- a/src/lib/common.ts
+++ b/src/lib/common.ts
@@ -13,10 +13,6 @@ import { SaleorAppList } from '../graphql/SaleorAppList.js';
 import { Config } from './config.js';
 import { isPortAvailable } from './detectPort.js';
 import {
-  getEnvironment,
-  getEnvironmentGraphqlEndpoint,
-} from './environment.js';
-import {
   NotSaleorAppDirectoryError,
   printlnSuccess,
   SaleorAppInstallError,
@@ -53,8 +49,8 @@ export const doSaleorAppDelete = async (argv: any) => {
 };
 
 export const doSaleorAppInstall = async (argv: any) => {
-  const endpoint =
-    argv.saleorApiUrl || (await getEnvironmentGraphqlEndpoint(argv));
+  const { instance } = argv;
+  const endpoint = `${instance}/graphql/`;
   const headers = await Config.getBearerHeader();
 
   if (!argv.manifestURL) {
@@ -104,7 +100,7 @@ export const doSaleorAppInstall = async (argv: any) => {
   } else {
     // open browser
     console.log('\nOpening the browser...');
-    const { domain } = await getEnvironment(argv);
+    const { instance: domain } = argv;
     const QueryParams = new URLSearchParams({ manifestUrl: manifestURL });
     const url = `https://${domain}/dashboard/apps/install?${QueryParams}`;
     console.log(url);

--- a/src/lib/environment.test.ts
+++ b/src/lib/environment.test.ts
@@ -5,7 +5,7 @@ import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
 import { Arguments } from 'yargs';
 
 import { Options } from '../types';
-import { getEnvironment, getEnvironmentGraphqlEndpoint } from './environment';
+import { getEnvironment } from './environment';
 import { configs } from './index';
 
 const environment = {
@@ -20,6 +20,7 @@ const argv = {
   token: 'XYZ',
   organization: 'test_org',
   environment: 'test',
+  instance: 'https://test-environment.test.saleor.cloud',
 } as Arguments<Options>;
 
 const handlers = [
@@ -51,11 +52,12 @@ describe('getEnvironment', () => {
   });
 });
 
-describe('getEnvironmentGraphqlEndpoint', () => {
+describe('get Saleor API endpoint', () => {
   it('should return the environment\'s graphql endpoint', async () => {
-    const response = await getEnvironmentGraphqlEndpoint(argv);
+    const { instance } = argv;
+    const endpoint = `${instance}/graphql/`;
 
-    expect(response).toEqual(
+    expect(endpoint).toEqual(
       'https://test-environment.test.saleor.cloud/graphql/'
     );
   });

--- a/src/lib/environment.ts
+++ b/src/lib/environment.ts
@@ -3,13 +3,6 @@ import { Arguments } from 'yargs';
 import { API, GET } from '../lib/index.js';
 import { Environment, Options } from '../types';
 
+// eslint-disable-next-line import/prefer-default-export
 export const getEnvironment = async (argv: Arguments<Options>) =>
   GET(API.Environment, argv) as Promise<Environment>;
-
-export const getEnvironmentGraphqlEndpoint = async (
-  argv: Arguments<Options>
-) => {
-  const { domain } = await getEnvironment(argv);
-
-  return `https://${domain}/graphql/`;
-};

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -15,7 +15,6 @@ import { SaleorAppList } from '../graphql/SaleorAppList.js';
 import { API, GET, POST, Region } from '../lib/index.js';
 import { Environment, Options, ProjectCreate } from '../types.js';
 import { Config } from './config.js';
-import { getEnvironmentGraphqlEndpoint } from './environment.js';
 
 export const delay = (ms: number) =>
   new Promise((resolve) => setTimeout(resolve, ms)); // eslint-disable-line no-promise-executor-return
@@ -110,7 +109,8 @@ const createPrompt = async (
 };
 
 export const makeRequestAppList = async (argv: any) => {
-  const endpoint = await getEnvironmentGraphqlEndpoint(argv);
+  const { instance } = argv;
+  const endpoint = `${instance}/graphql/`;
   const headers = await Config.getBearerHeader();
 
   const { data, errors }: any = await got
@@ -167,7 +167,8 @@ export const promptWebhook = async (argv: any) =>
     'webhookID',
     'Select a Webhook',
     async () => {
-      const endpoint = await getEnvironmentGraphqlEndpoint(argv);
+      const { instance } = argv;
+      const endpoint = `${instance}/graphql/`;
       const headers = await Config.getBearerHeader();
 
       const { app: appID } = argv;

--- a/src/middleware/index.ts
+++ b/src/middleware/index.ts
@@ -12,10 +12,7 @@ import { Arguments } from 'yargs';
 
 import * as Configuration from '../config.js';
 import { Config } from '../lib/config.js';
-import {
-  getEnvironment as getEnv,
-  getEnvironmentGraphqlEndpoint,
-} from '../lib/environment.js';
+import { getEnvironment as getEnv } from '../lib/environment.js';
 import { API, GET, getEnvironment } from '../lib/index.js';
 import { isNotFound } from '../lib/response.js';
 import {
@@ -339,7 +336,8 @@ mutation login($email: String!, $password: String!) {
       message: 'Your password?',
     });
 
-    const endpoint = await getEnvironmentGraphqlEndpoint(argv);
+    const { instance } = argv;
+    const endpoint = `${instance}/graphql/`;
 
     const { data, errors }: any = await got
       .post(endpoint, {


### PR DESCRIPTION
## I want to merge this PR because 

- it eliminates the direct calls to get the API instance endpoint. Instead, use the middlewares and harmonise this approach.

## Related (issues, PRs, topics)

- #523 

## Steps to test feature

- NA

## I have:

- [x] Tested it locally and it doesn't break existing features
- [ ] Added documentation if public changes are introduced
- [ ] Added tests for my code
