### PR TITLE
Print app URL to Dashboard for `app tunnel`

### DIFF
--- a/src/cli/app/tunnel.ts
+++ b/src/cli/app/tunnel.ts
@@ -101,7 +101,8 @@ export const handler = async (argv: Arguments<Options>): Promise<void> => {
     const gqlMsg = ` GraphQL Playground: ${chalk.blue(`${baseURL}/graphql/`)}`;
 
     contentBox(
-      `${saleorAppName}\n${saleorAppURLMessage}\n\n${dashboardMsg}\n${gqlMsg}`
+      `${saleorAppName}\n${saleorAppURLMessage}\n\n${dashboardMsg}\n${gqlMsg}`,
+      { borderBottom: false }
     );
 
     await delay(1000);
@@ -112,16 +113,21 @@ export const handler = async (argv: Arguments<Options>): Promise<void> => {
 
     // Find the App ID
     debug('Searching for a Saleor app named:', appName);
-    const app = await findSaleorAppByName(appName, _argv);
+    let app = await findSaleorAppByName(appName, _argv);
     debug('Saleor App found?', !app);
 
     if (!app || argv.forceInstall) {
       const spinner = ora('Installing... \n').start();
-
-      // TODO this should return App ID, now it returns an ID of a job installing the app
       await doSaleorAppInstall(_argv);
-      spinner.succeed();
+      spinner.stop();
+
+      app = await findSaleorAppByName(appName, _argv);
     }
+
+    const appDashboardURL = `${baseURL}/dashboard/apps/${encodeURIComponent(
+      app || ''
+    )}/app`;
+    contentBox(`Open app in Dashboard: ${chalk.blue(appDashboardURL)}`);
 
     console.log(
       `Tunnel is listening to your local machine on port: ${chalk.blue(

--- a/src/generated/graphql.ts
+++ b/src/generated/graphql.ts
@@ -60,6 +60,17 @@ export const GetWebhookSyncEventEnum = gql`
     }
   }
 `;
+export const AppsInstallations = gql`
+  query AppsInstallations {
+    appsInstallations {
+      id
+      manifestUrl
+      appName
+      message
+      status
+    }
+  }
+`;
 export const AppDelete = gql`
   mutation AppDelete($app: ID!) {
     appDelete(id: $app) {

--- a/src/graphql/SaleorAppsInstallations.graphql
+++ b/src/graphql/SaleorAppsInstallations.graphql
@@ -1,0 +1,9 @@
+query AppsInstallations {
+  appsInstallations {
+    id
+    manifestUrl
+    appName
+    message
+    status
+  }
+}


### PR DESCRIPTION
## I want to merge this PR because 
- it displays the app entry point in the Dashboard for `app tunnel`. 

This process needs some changes in the core side as seems to me there is no 100% correct way to identify id that the app got assigned. 

1.`AppInstall` mutation returns `AppInstallation`  which contains `appInstallation` id. 
2. Query `appsInstallations` provides the information about the ongoing installations (no app id yet). As soon as the installation is  "SUCCEEDED" it's no longer available in this query.
3. In order to get the app id query `apps` is needed, it returns the app id but at the same time there is no connection to the `AppInstallation` so we can't be 100% sure the app we assessed by installation date, name and manifest URL is the one.




<img width="731" alt="Screenshot 2022-11-10 at 13 10 36" src="https://user-images.githubusercontent.com/779644/201088160-fc2d54e2-fa3f-4d12-a06a-ea8158cbd671.png">

## Related (issues, PRs, topics)

- #469 

## Steps to test feature

- saleor app tunnel
- saleor app tunnel --force-install

## I have:

- [x] Tested it locally and it doesn't break existing features
- [ ] Added documentation if public changes are introduced
- [ ] Added tests for my code
