### PR TITLE
Status improvements - display env, verify auth tokens

### DIFF
--- a/src/cli/github/login.ts
+++ b/src/cli/github/login.ts
@@ -1,4 +1,5 @@
 import { CliUx } from '@oclif/core';
+import chalk from 'chalk';
 import Debug from 'debug';
 import detectPort from 'detect-port';
 import EventEmitter from 'events';
@@ -10,7 +11,7 @@ import { GET } from 'retes/route';
 import type { CommandBuilder } from 'yargs';
 
 import { Config } from '../../lib/config.js';
-import { delay } from '../../lib/util.js';
+import { delay, printlnSuccess } from '../../lib/util.js';
 
 const { ux: cli } = CliUx;
 
@@ -65,6 +66,7 @@ export const handler = async () => {
         const { access_token: accessToken } = data;
 
         await Config.set('github_token', `Bearer ${accessToken}`);
+        printlnSuccess(chalk.bold('success'));
       } catch (error: any) {
         console.log(error.message);
       }

--- a/src/cli/info.ts
+++ b/src/cli/info.ts
@@ -6,7 +6,7 @@ import type { CommandBuilder } from 'yargs';
 import pkg from '../../package.json';
 import { Config } from '../lib/config.js';
 import { header } from '../lib/images.js';
-import { API, GET } from '../lib/index.js';
+import { API, GET, getEnvironment } from '../lib/index.js';
 
 const { ux: cli } = CliUx;
 
@@ -61,7 +61,15 @@ export const handler = async (): Promise<void> => {
     const user = (await GET(API.User, { token })) as unknown;
 
     if (hasEmail(user)) {
-      console.log(chalk.green(`Hello ${user.email}, you're logged in`));
+      const environment = await getEnvironment();
+      console.log(
+        chalk.green(
+          'Hello',
+          user.email,
+          'you\'re logged in to Saleor API -',
+          environment
+        )
+      );
     }
   } catch (e) {
     console.log(chalk.blue('You\'re not logged in'));

--- a/src/cli/login.ts
+++ b/src/cli/login.ts
@@ -97,6 +97,7 @@ export const doLogin = async () => {
 
         await Config.reset();
         await Config.set('token', `Token ${token}`);
+        await Config.set('saleor_env', environment);
         await Config.set('user_session', userSession);
         for (const [name, value] of Object.entries(secrets)) {
           await Config.set(name as ConfigField, value);

--- a/src/cli/vercel/login.ts
+++ b/src/cli/vercel/login.ts
@@ -11,7 +11,7 @@ import { GET } from 'retes/route';
 import { Config, SaleorCLIPort } from '../../lib/config.js';
 import { checkPort } from '../../lib/detectPort.js';
 import { NoCommandBuilderSetup } from '../../lib/index.js';
-import { delay } from '../../lib/util.js';
+import { delay, printlnSuccess } from '../../lib/util.js';
 
 const { ux: cli } = CliUx;
 
@@ -66,6 +66,7 @@ export const handler = async () => {
 
         await Config.set('vercel_token', `Bearer ${accessToken}`);
         await Config.set('vercel_team_id', teamId);
+        printlnSuccess(chalk.bold('success'));
       } catch (error: any) {
         console.log(error.message);
         console.log(

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -46,7 +46,7 @@ const remove = async (field: ConfigField) => {
     (await fs.readJSON(DefaultConfigFile, { throws: false })) || {};
 
   delete content[field];
-  await fs.outputJSON(DefaultConfigFile, content);
+  await fs.outputJSON(DefaultConfigFile, content, { spaces: '\t' });
 
   return content;
 };


### PR DESCRIPTION
## I want to merge this PR because 

- it verifies Github & Vercel tokens' validity
- it displays user data for tokens - email and name
- it stores and displays the current environment for which user is logged in for `info` and `status` commands
- it prints `success` for `vercel login` & `github login`

## Related (issues, PRs, topics)

- #493

## Steps to test feature

- `saleor info`
- `saleor status`

## I have:

- [x] Tested it locally and it doesn't break existing features
- [ ] Added documentation if public changes are introduced
- [ ] Added tests for my code
