### PR TITLE
Check & handle env status flags

### DIFF
--- a/src/cli/app/install.ts
+++ b/src/cli/app/install.ts
@@ -3,7 +3,11 @@ import { Arguments, CommandBuilder } from 'yargs';
 
 import { doSaleorAppInstall } from '../../lib/common.js';
 import { obfuscateArgv, printContext } from '../../lib/util.js';
-import { useAppConfig, useInstanceConnector } from '../../middleware/index.js';
+import {
+  useAppConfig,
+  useAvailabilityChecker,
+  useInstanceConnector,
+} from '../../middleware/index.js';
 import { Options } from '../../types.js';
 
 const debug = Debug('saleor-cli:app:install');
@@ -39,4 +43,8 @@ export const handler = async (argv: Arguments<Options>) => {
   process.exit(0);
 };
 
-export const middlewares = [useAppConfig, useInstanceConnector];
+export const middlewares = [
+  useAppConfig,
+  useInstanceConnector,
+  useAvailabilityChecker,
+];

--- a/src/cli/app/list.ts
+++ b/src/cli/app/list.ts
@@ -11,7 +11,11 @@ import {
   getAppsFromResult,
   obfuscateArgv,
 } from '../../lib/util.js';
-import { useAppConfig, useInstanceConnector } from '../../middleware/index.js';
+import {
+  useAppConfig,
+  useAvailabilityChecker,
+  useInstanceConnector,
+} from '../../middleware/index.js';
 import { Options } from '../../types.js';
 
 const { ux: cli } = CliUx;
@@ -85,4 +89,8 @@ export const handler = async (argv: Arguments<Options>) => {
   process.exit(0);
 };
 
-export const middlewares = [useAppConfig, useInstanceConnector];
+export const middlewares = [
+  useAppConfig,
+  useInstanceConnector,
+  useAvailabilityChecker,
+];

--- a/src/cli/app/permission.ts
+++ b/src/cli/app/permission.ts
@@ -8,7 +8,11 @@ import { Arguments, CommandBuilder } from 'yargs';
 import { AppUpdate, GetPermissionEnum } from '../../generated/graphql.js';
 import { Config } from '../../lib/config.js';
 import { obfuscateArgv, printContext, println } from '../../lib/util.js';
-import { useAppConfig, useInstanceConnector } from '../../middleware/index.js';
+import {
+  useAppConfig,
+  useAvailabilityChecker,
+  useInstanceConnector,
+} from '../../middleware/index.js';
 import { Options } from '../../types.js';
 import { getSaleorApp } from './token.js';
 
@@ -111,4 +115,8 @@ const getPermissions = async (
   return permissions;
 };
 
-export const middlewares = [useAppConfig, useInstanceConnector];
+export const middlewares = [
+  useAppConfig,
+  useInstanceConnector,
+  useAvailabilityChecker,
+];

--- a/src/cli/app/token.ts
+++ b/src/cli/app/token.ts
@@ -13,7 +13,11 @@ import {
   obfuscateArgv,
   printContext,
 } from '../../lib/util.js';
-import { useAppConfig, useInstanceConnector } from '../../middleware/index.js';
+import {
+  useAppConfig,
+  useAvailabilityChecker,
+  useInstanceConnector,
+} from '../../middleware/index.js';
 import { Options } from '../../types.js';
 
 const debug = Debug('saleor-cli:app:token');
@@ -120,4 +124,8 @@ export const getSaleorApp = async (
   return { app, apps };
 };
 
-export const middlewares = [useAppConfig, useInstanceConnector];
+export const middlewares = [
+  useAppConfig,
+  useInstanceConnector,
+  useAvailabilityChecker,
+];

--- a/src/cli/app/tunnel.ts
+++ b/src/cli/app/tunnel.ts
@@ -16,7 +16,11 @@ import {
 } from '../../lib/common.js';
 import { Config } from '../../lib/config.js';
 import { contentBox, delay, obfuscateArgv } from '../../lib/util.js';
-import { useAppConfig, useInstanceConnector } from '../../middleware/index.js';
+import {
+  useAppConfig,
+  useAvailabilityChecker,
+  useInstanceConnector,
+} from '../../middleware/index.js';
 import { Options } from '../../types.js';
 
 const random = (min: number, max: number) =>
@@ -146,4 +150,5 @@ export const middlewares = [
   verifyIfSaleorAppRunning,
   useAppConfig,
   useInstanceConnector,
+  useAvailabilityChecker,
 ];

--- a/src/cli/app/uninstall.ts
+++ b/src/cli/app/uninstall.ts
@@ -8,7 +8,11 @@ import {
   println,
   SaleorAppUninstallError,
 } from '../../lib/util.js';
-import { useAppConfig, useInstanceConnector } from '../../middleware/index.js';
+import {
+  useAppConfig,
+  useAvailabilityChecker,
+  useInstanceConnector,
+} from '../../middleware/index.js';
 import { Options } from '../../types.js';
 
 const debug = Debug('saleor-cli:app:uninstall');
@@ -33,4 +37,8 @@ export const handler = async (argv: Arguments<Options>) => {
   }
 };
 
-export const middlewares = [useAppConfig, useInstanceConnector];
+export const middlewares = [
+  useAppConfig,
+  useInstanceConnector,
+  useAvailabilityChecker,
+];

--- a/src/cli/backup/index.ts
+++ b/src/cli/backup/index.ts
@@ -1,4 +1,8 @@
-import { useAppConfig, useInstanceConnector } from '../../middleware/index.js';
+import {
+  useAppConfig,
+  useBlockingTasksChecker,
+  useInstanceConnector,
+} from '../../middleware/index.js';
 import * as create from './create.js';
 import * as list from './list.js';
 import * as remove from './remove.js';
@@ -7,6 +11,6 @@ import * as show from './show.js';
 
 export default function (_: any) {
   _.command([list, create, show, remove, restore])
-    .middleware([useAppConfig, useInstanceConnector])
+    .middleware([useAppConfig, useInstanceConnector, useBlockingTasksChecker])
     .demandCommand(1, 'You need at least one command before moving on');
 }

--- a/src/cli/env/clear.ts
+++ b/src/cli/env/clear.ts
@@ -3,6 +3,7 @@ import type { Arguments, CommandBuilder } from 'yargs';
 
 import { API, GET } from '../../lib/index.js';
 import { obfuscateArgv, waitForTask } from '../../lib/util.js';
+import { useBlockingTasksChecker } from '../../middleware/index.js';
 import { Options } from '../../types.js';
 
 const debug = Debug('saleor-cli:env:clear');
@@ -23,3 +24,5 @@ export const handler = async (argv: Arguments<Options>) => {
   const result = (await GET(API.ClearDatabase, argv)) as any;
   await waitForTask(argv, result.task_id, 'Clearing', 'Yay! Database cleared!');
 };
+
+export const middlewares = [useBlockingTasksChecker];

--- a/src/cli/env/populate.ts
+++ b/src/cli/env/populate.ts
@@ -3,6 +3,7 @@ import type { Arguments, CommandBuilder } from 'yargs';
 
 import { API, GET } from '../../lib/index.js';
 import { obfuscateArgv, waitForTask } from '../../lib/util.js';
+import { useBlockingTasksChecker } from '../../middleware/index.js';
 import { Options } from '../../types.js';
 
 const debug = Debug('saleor-cli:env:populate');
@@ -28,3 +29,5 @@ export const handler = async (argv: Arguments<Options>) => {
     'Yay! Database populated!'
   );
 };
+
+export const middlewares = [useBlockingTasksChecker];

--- a/src/cli/job/list.ts
+++ b/src/cli/job/list.ts
@@ -5,7 +5,7 @@ import { Arguments, CommandBuilder } from 'yargs';
 
 import { API, GET } from '../../lib/index.js';
 import { formatDateTime, obfuscateArgv } from '../../lib/util.js';
-import { Options } from '../../types.js';
+import { Job, Options } from '../../types.js';
 
 const { ux: cli } = CliUx;
 
@@ -14,8 +14,6 @@ const parseJobName = (name: string) => {
 
   return { type, env, id };
 };
-
-// TODO environment required in config or as param!!!!!!
 
 const debug = Debug('saleor-cli:job:list');
 
@@ -27,7 +25,7 @@ export const builder: CommandBuilder = (_) =>
 
 export const handler = async (argv: Arguments<Options>) => {
   debug('command arguments: %O', obfuscateArgv(argv));
-  const result = (await GET(API.Job, argv)) as any[];
+  const result = (await GET(API.Job, argv)) as Job[];
 
   if (argv.json) {
     console.log(JSON.stringify(result, null, 2));
@@ -46,6 +44,8 @@ export const handler = async (argv: Arguments<Options>) => {
             return chalk.blue('CREATE');
           case 'bkp':
             return chalk.blue('BACKUP');
+          case 'rst':
+            return chalk.blue('RESTORE');
           default:
             return chalk.blue(type.toUpperCase());
         }
@@ -79,6 +79,4 @@ export const handler = async (argv: Arguments<Options>) => {
       get: ({ job_name: jobName }) => parseJobName(jobName).id,
     },
   });
-
-  process.exit(0);
 };

--- a/src/cli/webhook/index.ts
+++ b/src/cli/webhook/index.ts
@@ -1,4 +1,8 @@
-import { useAppConfig, useInstanceConnector } from '../../middleware/index.js';
+import {
+  useAppConfig,
+  useAvailabilityChecker,
+  useInstanceConnector,
+} from '../../middleware/index.js';
 import * as create from './create.js';
 import * as edit from './edit.js';
 import * as list from './list.js';
@@ -6,6 +10,6 @@ import * as update from './update.js';
 
 export default function (_: any) {
   _.command([list, create, edit, update])
-    .middleware([useAppConfig, useInstanceConnector])
+    .middleware([useAppConfig, useInstanceConnector, useAvailabilityChecker])
     .demandCommand(1, 'You need at least one command before moving on');
 }

--- a/src/middleware/index.ts
+++ b/src/middleware/index.ts
@@ -470,3 +470,35 @@ export const useVercel = async () => {
 
   return {};
 };
+
+export const useAvailabilityChecker = async (argv: Options) => {
+  const { maintenance_mode: maintenance, disabled } = await getEnv(
+    argv as Arguments
+  );
+
+  if (maintenance) {
+    throw new Error('The selected environment is in the maintenance mode');
+  }
+
+  if (disabled) {
+    throw new Error(
+      'The selected environment has exceeded maximum request count'
+    );
+  }
+
+  return {};
+};
+
+export const useBlockingTasksChecker = async (argv: Options) => {
+  const { blocking_tasks_in_progress: blockingTasksInProgress } = await getEnv(
+    argv as Arguments
+  );
+
+  if (blockingTasksInProgress) {
+    throw new Error(
+      'The selected operation can\'t be performed at the moment.\n Please wait for pending jobs to finish.'
+    );
+  }
+
+  return {};
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -103,3 +103,12 @@ export type Config = {
 export type ConfigMap = {
   [key: string]: Config;
 };
+
+export type Job = {
+  job_name: string;
+  created_at: string;
+  status: string;
+  status_message: string | null;
+  last_status_change: string;
+  is_blocking: boolean;
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -85,6 +85,9 @@ export interface Environment {
     version: string;
     service_type: string;
   };
+  maintenance_mode: boolean;
+  blocking_tasks_in_progress: boolean;
+  disabled: boolean;
 }
 
 export interface Task {


### PR DESCRIPTION
## I want to merge this PR because 

- it introduces checks for 
  - environment graphql endpoint availability - `useAvailabilityChecker` - which checks `maintenance_mode` and `disabled` flags
  - environment db layer availability  - `useBlockingTasksChecker` which checks `blocking_tasks_in_progress` flag

## Related (issues, PRs, topics)

- #364 

## Steps to test feature

- trigger the maintenance mode on the environment and run some of the webhook commands eg `saleor webhook list`
- `saleor backup restore` followed by one of `saleor env populate`, `saleor env clear`,  and any of `saleor backup` commands

## I have:

- [x] Tested it locally and it doesn't break existing features
- [ ] Added documentation if public changes are introduced
- [ ] Added tests for my code
