### PR TITLE
Detect headless mode for `login`

### DIFF
--- a/src/cli/configure.ts
+++ b/src/cli/configure.ts
@@ -21,13 +21,14 @@ export const command = 'configure [token]';
 export const desc = 'Configure Saleor CLI';
 
 export const builder: CommandBuilder = (_) =>
-  _.positional('token', { type: 'string', demandOption: false }).option(
-    'force',
-    {
-      type: 'boolean',
-      desc: 'skip additional prompts',
-    }
-  );
+  _.positional('token', {
+    type: 'string',
+    demandOption: false,
+    desc: 'token created at https://cloud.saleor.io/tokens',
+  }).option('force', {
+    type: 'boolean',
+    desc: 'skip additional prompts',
+  });
 
 export const handler = async (argv: Arguments<Options>) => {
   debug('command arguments: %O', obfuscateArgv(argv));

--- a/src/cli/login.ts
+++ b/src/cli/login.ts
@@ -13,7 +13,7 @@ import { GET } from 'retes/route';
 import { Config, ConfigField, SaleorCLIPort } from '../lib/config.js';
 import { checkPort } from '../lib/detectPort.js';
 import { API, getAmplifyConfig, getEnvironment, POST } from '../lib/index.js';
-import { delay } from '../lib/util.js';
+import { delay, println } from '../lib/util.js';
 
 const { ux: cli } = CliUx;
 
@@ -53,7 +53,23 @@ export const doLogin = async () => {
   debug(`prepare the OAuth params: ${JSON.stringify(QueryParams, null, 2)}`);
 
   const url = `https://${amplifyConfig.oauth.domain}/login?${QueryParams}`;
-  cli.open(url);
+
+  try {
+    cli.open(url);
+  } catch (error: any) {
+    if (error.code === 'ENOENT') {
+      println('This command requires browser to operate');
+      println(
+        chalk(
+          'In the headless environment use',
+          chalk.green('saleor configure')
+        )
+      );
+      process.exit(1);
+    }
+
+    throw error;
+  }
 
   const app = new ServerApp([
     GET('/', async ({ params }) => {


### PR DESCRIPTION
## I want to merge this PR because 

- It catches `ENOENT` error which indicates the headless mode. In such case the `configure` command should be used instead.

## Related (issues, PRs, topics)

- #548 

## Steps to test feature

- `saleor login` in the headless environment

## I have:

- [x] Tested it locally and it doesn't break existing features
- [ ] Added documentation if public changes are introduced
- [ ] Added tests for my code
