### PR TITLE
Validate targetUrl for `webhook create`

### DIFF
--- a/src/graphql/doWebhookCreate.ts
+++ b/src/graphql/doWebhookCreate.ts
@@ -5,6 +5,10 @@ export const doWebhookCreate = /* GraphQL */ `
       webhook {
         id
       }
+      errors {
+        field
+        message
+      }
     }
   }
 `;

--- a/src/types.ts
+++ b/src/types.ts
@@ -112,3 +112,8 @@ export type Job = {
   last_status_change: string;
   is_blocking: boolean;
 };
+
+export type WebhookError = {
+  field: string;
+  message: string;
+};


### PR DESCRIPTION
## I want to merge this PR because 

- it adds simple ` targetUrl` validation and errors handling for `webhook create` command

## Related (issues, PRs, topics)

- #415 

## Steps to test feature

- `saleor webhook create`

## I have:

- [x] Tested it locally and it doesn't break existing features
- [ ] Added documentation if public changes are introduced
- [ ] Added tests for my code
