### PR TITLE
Allow yargs to use width of more than 80 chars

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -132,6 +132,7 @@ const parser = yargs(hideBin(process.argv))
   .middleware([useOnlineChecker, useTelemetry(pkg.version)])
   .demandCommand(1, 'You need at least one command before moving on')
   .alias('h', 'help')
+  .wrap(null)
   .epilogue('for more information, find the documentation at https://saleor.io')
   .fail(async (msg, error, _yargs) => {
     if (error) {


### PR DESCRIPTION
## I want to merge this PR because 

- It allows yargs to use a width longer than 80 characters in the terminal

## Related (issues, PRs, topics)

- NA

## Steps to test feature

- 

## I have:

- [x] Tested it locally and it doesn't break existing features
- [ ] Added documentation if public changes are introduced
- [ ] Added tests for my code
