### PR TITLE
Add missing desc for `app tunnel` options

### DIFF
--- a/src/cli/app/tunnel.ts
+++ b/src/cli/app/tunnel.ts
@@ -47,8 +47,16 @@ export const builder: CommandBuilder = (_) =>
       demandOption: false,
       desc: 'The application name for installation in the Dashboard',
     })
-    .option('force-install', { type: 'boolean', default: false })
-    .option('use-ngrok', { type: 'boolean', default: false });
+    .option('force-install', {
+      type: 'boolean',
+      default: false,
+      desc: 'Force the Saleor App Install',
+    })
+    .option('use-ngrok', {
+      type: 'boolean',
+      default: false,
+      desc: 'Use `ngrok` binary instead of the built-in tunnel',
+    });
 
 export const handler = async (argv: Arguments<Options>): Promise<void> => {
   debug('command arguments: %O', obfuscateArgv(argv));


### PR DESCRIPTION
## I want to merge this PR because 

- it adds the missing descriptions for options of the `app tunnel` command

## Related (issues, PRs, topics)

- #568

## Steps to test feature

- NA

## I have:

- [X] Tested it locally and it doesn't break existing features
- [ ] Added documentation if public changes are introduced
- [ ] Added tests for my code
