### PR TITLE
Use domain to verify env presence for instance param

### DIFF
--- a/src/lib/instance.ts
+++ b/src/lib/instance.ts
@@ -16,14 +16,7 @@ export const extractDataFromInstance = async (argv: Options) => {
   const spinner = ora('Getting instance details...').start();
   const { instance } = argv;
 
-  const match = instance?.match(/(?:http[s]*:\/\/)*(.*?)\.(?=[^/]*\..{2,5})/i);
-
-  if (!match) {
-    spinner.fail();
-    throw new Error('The environment not found');
-  }
-
-  const envName = match[1];
+  const { host } = new URL(instance ?? '');
 
   const organizations = (await GET(API.Organization, {
     ...argv,
@@ -38,8 +31,8 @@ export const extractDataFromInstance = async (argv: Options) => {
         environment: '',
       })) as Environment[];
 
-      if (environments.map((e) => e.name).includes(envName)) {
-        const environment = environments.filter((e) => e.name === envName)[0];
+      if (environments.map((e) => e.domain).includes(host)) {
+        const environment = environments.filter((e) => e.domain === host)[0];
 
         spinner.succeed();
         return {


### PR DESCRIPTION
## I want to merge this PR because 

- it uses the environment domain for environment inference while the instance parameter is provided

## Related (issues, PRs, topics)

- #569 

## Steps to test feature

- `saleor app install --instance=SALEOR_INSTANCE_URL`

## I have:

- [x] Tested it locally and it doesn't break existing features
- [ ] Added documentation if public changes are introduced
- [ ] Added tests for my code
