### PR TITLE
Add alias for positional in `backup remove`

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -681,7 +681,7 @@ Commands:
   saleor backup list [key|environment]    List backups of the environment
   saleor backup create <name>             Create a new backup
   saleor backup show [backup|backup-key]  Show a specific backup
-  saleor backup remove <key>              Remove the backup
+  saleor backup remove <key|backup>       Remove the backup
   saleor backup restore [from]            Restore a specific backup
 
 Options:
@@ -767,12 +767,12 @@ $ saleor backup remove --help
 Help output:
 
 ```
-saleor backup remove <key>
+saleor backup remove <key|backup>
 
 Remove the backup
 
 Positionals:
-  key  key of the backup  [string] [required]
+  key, backup  key of the backup  [string] [required]
 
 Options:
       --json             Output the data as JSON  [boolean]

--- a/src/cli/backup/remove.ts
+++ b/src/cli/backup/remove.ts
@@ -12,7 +12,7 @@ import { Options } from '../../types.js';
 
 const debug = Debug('saleor-cli:backup:remove');
 
-export const command = 'remove <key>';
+export const command = 'remove <key|backup>';
 export const desc = 'Remove the backup';
 
 export const builder: CommandBuilder = (_) =>


### PR DESCRIPTION
## I want to merge this PR because 

- It adds a `backup` alias to the positional parameter which is required in the `backup remove` route.

## Related (issues, PRs, topics)

- #557 

## Steps to test feature

- `saleor backup remove BACKUP_KEY`

## I have:

- [x] Tested it locally and it doesn't break existing features
- [x] Added documentation if public changes are introduced
- [ ] Added tests for my code
