### PR TITLE
Narrow down files for package

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "release": "release-it --dry-run"
   },
   "files": [
-    "dist",
+    "dist/saleor.js",
     "template",
     "scripts"
   ],


### PR DESCRIPTION
## I want to merge this PR because 

- it narrows down `dist` files to `saleor.json`. Recently added `--sourcemap` param generates a source map which shouldn't be put into the release package.

## Related (issues, PRs, topics)

- 

## Steps to test feature

- 

## I have:

- [x] Tested it locally and it doesn't break existing features
- [ ] Added documentation if public changes are introduced
- [ ] Added tests for my code
