### PR TITLE
Configurable app manifest path

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1410,8 +1410,17 @@ Options:
       --name             The application name for installation in the Dashboard  [string]
       --force-install    Force the Saleor App Install  [boolean] [default: false]
       --use-ngrok        Use `ngrok` binary instead of the built-in tunnel  [boolean] [default: false]
+      --manifest-path    The application's manifest path  [string] [default: "/api/manifest"]
   -V, --version          Show version number  [boolean]
   -h, --help             Show help  [boolean]
+
+Examples:
+  saleor app tunnel --manifest-path=/app/manifest
+  saleor app tunnel --name="Custom name"
+  saleor app tunnel --force-install
+  saleor app tunnel --use-ngrok
+  saleor app tunnel --manifest-path=/app/manifest
+  saleor app tunnel --organization=organization-slug --environment=env-id-or-name
 ```
 
 #### app token
@@ -1484,11 +1493,13 @@ Options:
       --register-url     specify your own endpoint for registering apps  [string] [default: "https://appraptor.vercel.app/api/register-app"]
       --encrypt-url      specify your own endpoint for encrypting tokens  [string] [default: "https://appraptor.vercel.app/api/encrypt"]
       --github-prompt    specify prompt presence for repository creation on Github  [boolean] [default: "true"]
+      --manifest-path    The application's manifest path  [string] [default: "/api/manifest"]
   -V, --version          Show version number  [boolean]
   -h, --help             Show help  [boolean]
 
 Examples:
   saleor app deploy --no-github-prompt
+  saleor app deploy --no-github-prompt --manifest-path=/app/manifest
   saleor app deploy --organization=organization-slug --environment=env-id-or-name --no-github-prompt
 ```
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1415,7 +1415,6 @@ Options:
   -h, --help             Show help  [boolean]
 
 Examples:
-  saleor app tunnel --manifest-path=/app/manifest
   saleor app tunnel --name="Custom name"
   saleor app tunnel --force-install
   saleor app tunnel --use-ngrok

--- a/src/cli/app/deploy.ts
+++ b/src/cli/app/deploy.ts
@@ -59,7 +59,16 @@ export const builder: CommandBuilder = (_) =>
       demandOption: false,
       desc: 'specify prompt presence for repository creation on Github',
     })
+    .option('manifest-path', {
+      type: 'string',
+      default: '/api/manifest',
+      desc: 'The application\'s manifest path',
+    })
     .example('saleor app deploy --no-github-prompt', '')
+    .example(
+      'saleor app deploy --no-github-prompt --manifest-path=/app/manifest',
+      ''
+    )
     .example(
       'saleor app deploy --organization=organization-slug --environment=env-id-or-name --no-github-prompt',
       ''
@@ -164,7 +173,7 @@ export const handler = async (argv: Arguments<Options>) => {
 
   const domain = await vercel.getProjectDomain(projectId);
 
-  const projectManifestURL = `https://${domain.name}/api/manifest`;
+  const projectManifestURL = `https://${domain.name}${argv.manifestPath}`;
 
   const msg1 = ` ${chalk.dim('Using the CLI')}: ${chalk.green(
     'saleor app install'

--- a/src/cli/app/deploy.ts
+++ b/src/cli/app/deploy.ts
@@ -4,7 +4,10 @@ import GitUrlParse from 'git-url-parse';
 import fetch from 'node-fetch';
 import type { Arguments, CommandBuilder } from 'yargs';
 
-import { verifyIsSaleorAppDirectory } from '../../lib/common.js';
+import {
+  buildManifestURL,
+  verifyIsSaleorAppDirectory,
+} from '../../lib/common.js';
 import { Config } from '../../lib/config.js';
 import {
   createProjectInVercel,
@@ -27,7 +30,7 @@ import {
   useInstanceConnector,
   useVercel,
 } from '../../middleware/index.js';
-import { Options } from '../../types.js';
+import { AppDeploy, Options } from '../../types.js';
 
 const debug = Debug('saleor-cli:app:deploy');
 
@@ -74,7 +77,7 @@ export const builder: CommandBuilder = (_) =>
       ''
     );
 
-export const handler = async (argv: Arguments<Options>) => {
+export const handler = async (argv: Arguments<AppDeploy>) => {
   debug('command arguments: %O', obfuscateArgv(argv));
 
   const name = await getPackageName();
@@ -173,7 +176,10 @@ export const handler = async (argv: Arguments<Options>) => {
 
   const domain = await vercel.getProjectDomain(projectId);
 
-  const projectManifestURL = `https://${domain.name}${argv.manifestPath}`;
+  const projectManifestURL = buildManifestURL(
+    argv.manifestPath,
+    `https://${domain.name}`
+  );
 
   const msg1 = ` ${chalk.dim('Using the CLI')}: ${chalk.green(
     'saleor app install'

--- a/src/cli/app/tunnel.ts
+++ b/src/cli/app/tunnel.ts
@@ -56,7 +56,21 @@ export const builder: CommandBuilder = (_) =>
       type: 'boolean',
       default: false,
       desc: 'Use `ngrok` binary instead of the built-in tunnel',
-    });
+    })
+    .option('manifest-path', {
+      type: 'string',
+      default: '/api/manifest',
+      desc: 'The application\'s manifest path',
+    })
+    .example('saleor app tunnel --manifest-path=/app/manifest', '')
+    .example('saleor app tunnel --name="Custom name"', '')
+    .example('saleor app tunnel --force-install', '')
+    .example('saleor app tunnel --use-ngrok', '')
+    .example('saleor app tunnel --manifest-path=/app/manifest', '')
+    .example(
+      'saleor app tunnel --organization=organization-slug --environment=env-id-or-name',
+      ''
+    );
 
 export const handler = async (argv: Arguments<Options>): Promise<void> => {
   debug('command arguments: %O', obfuscateArgv(argv));
@@ -159,7 +173,7 @@ export const handler = async (argv: Arguments<Options>): Promise<void> => {
   await delay(1000);
 
   const _argv = argv;
-  _argv.manifestURL = `${tunnelURL}/api/manifest`;
+  _argv.manifestURL = `${tunnelURL}${argv.manifestPath}`;
   _argv.appName = appName;
 
   // Find the App ID

--- a/src/cli/checkout/deploy.ts
+++ b/src/cli/checkout/deploy.ts
@@ -6,7 +6,7 @@ import { Config } from '../../lib/config.js';
 import { setupSaleorAppCheckout } from '../../lib/deploy.js';
 import { contentBox, obfuscate, obfuscateArgv } from '../../lib/util.js';
 import { Vercel } from '../../lib/vercel.js';
-import { Options } from '../../types.js';
+import { Deploy } from '../../types.js';
 
 const debug = Debug('saleor-cli:checkout:deploy');
 
@@ -26,7 +26,7 @@ export const builder: CommandBuilder = (_) =>
       ''
     );
 
-export const handler = async (argv: Arguments<Options>) => {
+export const handler = async (argv: Arguments<Deploy>) => {
   debug('command arguments: %O', obfuscateArgv(argv));
 
   const domain = argv.instance;

--- a/src/lib/common.ts
+++ b/src/lib/common.ts
@@ -165,6 +165,15 @@ const waitForAppInstallation = async (argv: any, id: string) => {
   return true;
 };
 
+export const buildManifestURL = (origin: string, path: string) => {
+  try {
+    const manifestURL = new URL(path, origin);
+    return manifestURL.toString();
+  } catch {
+    throw new Error('The provided manifest URL is invalid');
+  }
+};
+
 export const fetchSaleorAppList = async (argv: any) => {
   const endpoint = `${argv.instance}/graphql/`;
   const headers = await Config.getBearerHeader();

--- a/src/lib/deploy.ts
+++ b/src/lib/deploy.ts
@@ -13,7 +13,7 @@ import { Arguments } from 'yargs';
 
 import { createAppToken } from '../cli/app/token.js';
 import { SaleorAppList } from '../graphql/SaleorAppList.js';
-import { Options } from '../types.js';
+import { Deploy, Options } from '../types.js';
 import { doSaleorAppInstall } from './common.js';
 import { Config } from './config.js';
 import {
@@ -244,7 +244,7 @@ export const getGithubRepository = async (
 export const setupSaleorAppCheckout = async (
   url: string,
   vercel: Vercel,
-  argv: Arguments<Options>
+  argv: Arguments<Deploy>
 ) => {
   const pkgName = await getPackageName();
   validateVercelProjectName(pkgName);

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -14,7 +14,7 @@ import { Arguments } from 'yargs';
 import { SaleorAppByID } from '../graphql/SaleorAppByID.js';
 import { SaleorAppList } from '../graphql/SaleorAppList.js';
 import { API, GET, POST, Region } from '../lib/index.js';
-import { Environment, Options, ProjectCreate } from '../types.js';
+import { BaseOptions, Environment, Options, ProjectCreate } from '../types.js';
 import { Config } from './config.js';
 
 export const delay = (ms: number) =>
@@ -211,7 +211,7 @@ export const printlnSuccess = (msg: string) =>
   println(chalk.green(logSymbols.success), msg);
 
 export const obfuscate = (value: string) => `${value.slice(0, 12)} ****`;
-export const obfuscateArgv = (argv: Arguments<Options>) => {
+export const obfuscateArgv = (argv: Arguments<BaseOptions>) => {
   // immutable
   // structuredClone, available from Node.js 17
   const argvCopy = Object.fromEntries(Object.entries(argv));

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,12 +26,8 @@ export interface Options extends BaseOptions {
   key?: string;
   json?: boolean;
   event?: string;
-  port?: string;
   name?: string;
-  encryptUrl?: string;
-  registerUrl?: string;
   saleorApiUrl?: string;
-  githubPrompt?: boolean;
   appId?: string;
   permissions?: string[];
 }
@@ -68,9 +64,27 @@ export interface StoreCreate extends BaseOptions {
   example?: string;
 }
 
-export interface StoreDeploy extends BaseOptions {
+export interface Deploy extends BaseOptions {
+  dispatch: boolean;
+  githubPrompt: boolean;
+}
+
+export interface StoreDeploy extends Deploy {
   withCheckout: boolean;
-  githubPrompt?: boolean;
+}
+
+export interface AppTunnel extends BaseOptions {
+  name: string;
+  port: number;
+  forceInstall: boolean;
+  useNgrok: boolean;
+  manifestPath: string;
+}
+
+export interface AppDeploy extends Deploy {
+  registerUrl: string;
+  encryptUrl: string;
+  manifestPath: string;
 }
 
 export interface Environment {


### PR DESCRIPTION
## I want to merge this PR because 

- it allows to define manifest path for `app tunnel` & `app deploy` commands

## Related (issues, PRs, topics)

- https://github.com/saleor/saleor-app-sdk/issues/54

## Steps to test feature

- `saleor app tunnel --manifest-path=/manifest`
- `saleor app deploy --manifest-path=/manifest`

## I have:

- [x] Tested it locally and it doesn't break existing features
- [ ] Added documentation if public changes are introduced
- [ ] Added tests for my code
