### PR TITLE
Use exit code as error indicator

### DIFF
--- a/test/helper.ts
+++ b/test/helper.ts
@@ -88,14 +88,14 @@ export const verifyTestProjectPresence = async (
 ) => {
   const params = ['project', 'list', `--organization=${organization}`];
 
-  const { err, output } = await trigger(command, params, {});
+  const { err, output, exitCode } = await trigger(command, params, {});
 
   if (output.join('').includes(` ${project} `)) {
     console.log('Project exists');
     return true;
   }
 
-  if (err.length > 0) {
+  if (exitCode !== 0) {
     throw new Error(err.join());
   }
 


### PR DESCRIPTION
## I want to merge this PR because 

- as the `stderr` may contain non error data,  exit code is the proper error indicator

## Related (issues, PRs, topics)

- https://github.com/saleor/saleor-cli/actions/runs/3644875838

## Steps to test feature

- 

## I have:

- [ ] Tested it locally and it doesn't break existing features
- [ ] Added documentation if public changes are introduced
- [ ] Added tests for my code
