### PR TITLE
Fix argumets order for buildManifestURL

### DIFF
--- a/src/lib/common.ts
+++ b/src/lib/common.ts
@@ -165,7 +165,7 @@ const waitForAppInstallation = async (argv: any, id: string) => {
   return true;
 };
 
-export const buildManifestURL = (origin: string, path: string) => {
+export const buildManifestURL = (path: string, origin: string) => {
   try {
     const manifestURL = new URL(path, origin);
     return manifestURL.toString();


### PR DESCRIPTION
## I want to merge this PR because 

- it sets proper order of arguments for buildManifestURL

## Related (issues, PRs, topics)

- 

## Steps to test feature

- `saleor app tunnel`
- `saleor app deploy` 

## I have:

- [ ] Tested it locally and it doesn't break existing features
- [ ] Added documentation if public changes are introduced
- [ ] Added tests for my code
