### PR TITLE
Add `open` command

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -48,7 +48,7 @@ Commands:
   saleor vercel [command]
   saleor github [command]
   saleor checkout [command]
-  saleor open [resource]         Open <resource>
+  saleor open [resource]         Open resource in browser
 
 Options:
       --json             Output the data as JSON  [boolean]
@@ -1629,7 +1629,7 @@ Help output:
 ```
 saleor open [resource]
 
-Open <resource>
+Open resource in browser
 
 Positionals:
   resource  [string] [choices: "dashboard", "api", "docs", "docs/api", "docs/apps", "docs/webhooks", "docs/checkout", "docs/storefront", "docs/cli"]

--- a/docs/README.md
+++ b/docs/README.md
@@ -48,6 +48,7 @@ Commands:
   saleor vercel [command]
   saleor github [command]
   saleor checkout [command]
+  saleor open [resource]         Open <resource>
 
 Options:
       --json             Output the data as JSON  [boolean]
@@ -125,6 +126,7 @@ for more information, find the documentation at https://saleor.io
   * [github login](#github-login)
 * [checkout](#checkout)
   * [checkout deploy](#checkout-deploy)
+* [open](#open)
 
 ### info
 
@@ -1614,4 +1616,33 @@ Options:
 Examples:
   saleor checkout deploy --no-github-prompt
   saleor checkout deploy --organization=organization-slug --environment=env-id-or-name --no-github-prompt
+```
+
+### open
+
+```sh
+$ saleor open --help
+```
+
+Help output:
+
+```
+saleor open [resource]
+
+Open <resource>
+
+Positionals:
+  resource  [string] [choices: "dashboard", "api", "docs", "docs/api", "docs/apps", "docs/webhooks", "docs/checkout", "docs/storefront", "docs/cli"]
+
+Options:
+      --json             Output the data as JSON  [boolean]
+      --short            Output data as text  [boolean] [default: false]
+  -u, --instance, --url  [string]
+  -V, --version          Show version number  [boolean]
+  -h, --help             Show help  [boolean]
+
+Examples:
+  saleor open dashboard  Open instance dashboard
+  saleor open api        Open instance GraphQL endpoint
+  saleor open docs       Open Saleor documentation page
 ```

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -22,6 +22,7 @@ import * as info from './cli/info.js';
 import job from './cli/job/index.js';
 import * as login from './cli/login.js';
 import * as logout from './cli/logout.js';
+import * as open from './cli/open.js';
 import organization from './cli/organization/index.js';
 import project from './cli/project/index.js';
 import * as register from './cli/register.js';
@@ -131,6 +132,7 @@ const parser = yargs(hideBin(process.argv))
   .command(['github [command]'], '', github)
   .command(['checkout [command]'], '', checkout)
   .command(['dev [command]'], false, dev)
+  .command(open)
   .option('json', { type: 'boolean', desc: 'Output the data as JSON' })
   .option('short', {
     type: 'boolean',

--- a/src/cli/login.ts
+++ b/src/cli/login.ts
@@ -39,7 +39,7 @@ export const builder: CommandBuilder = (_) =>
     })
     .example('saleor login', '')
     .example('saleor login --headless', '')
-    .example('saleor login --headless --token=TOKEN');
+    .example('saleor login --headless --token=TOKEN', '');
 
 export const handler = async (argv: Arguments<BaseOptions>) => {
   if (argv.headless) {

--- a/src/cli/open.ts
+++ b/src/cli/open.ts
@@ -6,7 +6,7 @@ import { useInstanceConnector } from '../middleware';
 import { Options } from '../types';
 
 export const command = 'open [resource]';
-export const desc = 'Open <resource>';
+export const desc = 'Open resource in browser';
 
 const resources: Record<string, string> = {
   dashboard: '/dashboard',

--- a/src/cli/open.ts
+++ b/src/cli/open.ts
@@ -1,0 +1,62 @@
+import Enquirer from 'enquirer';
+import { Arguments, CommandBuilder } from 'yargs';
+
+import { openURL } from '../lib/util';
+import { useInstanceConnector } from '../middleware';
+import { Options } from '../types';
+
+export const command = 'open [resource]';
+export const desc = 'Open <resource>';
+
+const resources: Record<string, string> = {
+  dashboard: '/dashboard',
+  api: '/graphql/',
+  docs: 'https://docs.saleor.io/docs/3.x/',
+  'docs/api': 'https://docs.saleor.io/docs/3.x/developer',
+  'docs/apps':
+    'https://docs.saleor.io/docs/3.x/developer/extending/apps/key-concepts',
+  'docs/webhooks':
+    'https://docs.saleor.io/docs/3.x/developer/extending/apps/asynchronous-webhooks',
+  'docs/checkout':
+    'https://github.com/saleor/react-storefront/blob/canary/apps/saleor-app-checkout/README.md',
+  'docs/storefront': 'https://github.com/saleor/react-storefront',
+  'docs/cli': 'https://docs.saleor.io/docs/3.x/cli',
+};
+
+export const builder: CommandBuilder = (_) =>
+  _.positional('resource', {
+    type: 'string',
+    demandOption: true,
+    choices: Object.keys(resources),
+  })
+    .example('saleor open dashboard', 'Open instance dashboard')
+    .example('saleor open api', 'Open instance GraphQL endpoint')
+    .example('saleor open docs', 'Open Saleor documentation page');
+
+export const handler = async (argv: Arguments<Options>) => {
+  const choices = Object.keys(resources);
+
+  const { resource } = await Enquirer.prompt<{ resource: string }>({
+    type: 'select',
+    name: 'resource',
+    choices,
+    message: 'Choose the resource',
+    skip: choices.includes(argv.resource as string),
+  });
+
+  const path = resources[resource || (argv.resource as string)];
+
+  if (!path.startsWith('https')) {
+    const url = await getURL(path, argv);
+    await openURL(url);
+    return;
+  }
+
+  await openURL(path);
+};
+
+const getURL = async (path: string, argv: Arguments<Options>) => {
+  const _argv = await useInstanceConnector(argv);
+  const { instance } = _argv;
+  return `${instance}${path}`;
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -87,6 +87,10 @@ export interface AppDeploy extends Deploy {
   manifestPath: string;
 }
 
+export interface Open extends BaseOptions {
+  resource?: string;
+}
+
 export interface Environment {
   name: string;
   key: string;


### PR DESCRIPTION
It opens the browser with docs or instance page

## I want to merge this PR because 

- It adds an `open` command which opens the browser with docs or instance page

## Related (issues, PRs, topics)

- 

## Steps to test feature

- `saleor open`
- `saleor open dashboard`
- `saleor open api`
- `saleor open docs`

## I have:

- [x] Tested it locally and it doesn't break existing features
- [x] Added documentation if public changes are introduced
- [ ] Added tests for my code
