### PR TITLE
Add `webhook dry-run` command

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -111,6 +111,7 @@ for more information, find the documentation at https://saleor.io
   * [webhook create](#webhook-create)
   * [webhook edit](#webhook-edit)
   * [webhook update](#webhook-update)
+  * [webhook dry-run](#webhook-dry-run)
 * [app](#app)
   * [app list](#app-list)
   * [app install](#app-install)
@@ -1144,10 +1145,11 @@ Help output:
 saleor webhook [command]
 
 Commands:
-  saleor webhook list    List webhooks for an environment
-  saleor webhook create  Create a new webhook
-  saleor webhook edit    Edit a webhook
-  saleor webhook update  Update webhooks for an environment
+  saleor webhook list     List webhooks for an environment
+  saleor webhook create   Create a new webhook
+  saleor webhook edit     Edit a webhook
+  saleor webhook update   Update webhooks for an environment
+  saleor webhook dry-run  Webhook dry run
 
 Options:
       --json             Output the data as JSON  [boolean]
@@ -1239,6 +1241,34 @@ Options:
   -u, --instance, --url  [string]
   -V, --version          Show version number  [boolean]
   -h, --help             Show help  [boolean]
+```
+
+#### webhook dry-run
+
+```sh
+$ saleor webhook dry-run --help
+```
+
+Help output:
+
+```
+saleor webhook dry-run
+
+Webhook dry run
+
+Options:
+      --json             Output the data as JSON  [boolean]
+      --short            Output data as text  [boolean] [default: false]
+  -u, --instance, --url  [string]
+      --object-id        Object ID to perform dry run on  [string]
+      --query            Subscription query  [boolean]
+  -V, --version          Show version number  [boolean]
+  -h, --help             Show help  [boolean]
+
+Examples:
+  saleor webhook dry-run
+  saleor webhook dry-run --query='subscription { event { ... on ProductCreated { product { id name } } } }'
+  saleor webhook dry-run --object-id='UHJvZHVjdDo3Mg=='
 ```
 
 ### app

--- a/src/cli/webhook/dryRun.ts
+++ b/src/cli/webhook/dryRun.ts
@@ -1,0 +1,109 @@
+import chalk from 'chalk';
+import Debug from 'debug';
+import Enquirer from 'enquirer';
+import got, { HTTPError } from 'got';
+import { Arguments, CommandBuilder } from 'yargs';
+
+import { doWebhookDryRun } from '../../graphql/doWebhookDryRun.js';
+import { Config } from '../../lib/config.js';
+import { obfuscateArgv, println, showResult } from '../../lib/util.js';
+import { WebhookDryRun, WebhookError } from '../../types.js';
+
+const debug = Debug('saleor-cli:webhook:create');
+
+export const command = 'dry-run';
+export const desc = 'Webhook dry run';
+
+export const builder: CommandBuilder = (_) =>
+  _.option('object-id', {
+    type: 'string',
+    demandOption: false,
+    desc: 'Object ID to perform dry run on',
+  })
+    .option('query', {
+      type: 'boolean',
+      desc: 'Subscription query',
+    })
+    .example('saleor webhook dry-run', '')
+    .example(
+      'saleor webhook dry-run --query=\'subscription { event { ... on ProductCreated { product { id name } } } }\'',
+      ''
+    )
+    .example('saleor webhook dry-run --object-id=\'UHJvZHVjdDo3Mg==\'', '');
+
+export const handler = async (argv: Arguments<WebhookDryRun>) => {
+  debug('command arguments: %O', obfuscateArgv(argv));
+
+  const { objectId, query } = await Enquirer.prompt<{
+    objectId: string;
+    query: string;
+  }>([
+    {
+      type: 'input',
+      name: 'objectId',
+      message: 'Object ID to perform Dry Run on',
+      initial: argv.objectId,
+      required: true,
+      skip: !!argv.objectId,
+    },
+    {
+      type: 'input',
+      name: 'query',
+      message: 'Subscription query',
+      initial:
+        argv.query ||
+        'subscription { event { ... on ProductCreated { product { id name } } } }',
+      required: true,
+      skip: !!argv.query,
+    },
+  ]);
+
+  const { instance } = argv;
+  const endpoint = `${instance}/graphql/`;
+  const headers = await Config.getBearerHeader();
+
+  try {
+    const { data }: any = await got
+      .post(endpoint, {
+        headers,
+        json: {
+          query: doWebhookDryRun,
+          variables: {
+            objectId,
+            query,
+          },
+        },
+      })
+      .json();
+
+    const { webhookDryRun } = data;
+
+    println('');
+
+    if (!webhookDryRun) {
+      println(chalk.red('Couldn\'t find the provided object'));
+      return;
+    }
+
+    const { payload, errors = [] } = webhookDryRun ?? {};
+
+    if (errors.length) {
+      throw new Error(
+        errors.map((e: WebhookError) => `\n ${e.field} - ${e.message}`).join()
+      );
+    }
+
+    println(payload);
+  } catch (error) {
+    if (error instanceof HTTPError) {
+      const { statusCode } = error.response;
+      if (statusCode === 400) {
+        throw new Error(
+          'Seems the selected environment doesn\'t support dry run feature. Required Saleor Version ^3.11'
+        );
+      }
+    }
+
+    throw error;
+  }
+};

--- a/src/cli/webhook/index.ts
+++ b/src/cli/webhook/index.ts
@@ -4,12 +4,13 @@ import {
   useInstanceConnector,
 } from '../../middleware/index.js';
 import * as create from './create.js';
+import * as dryRun from './dryRun.js';
 import * as edit from './edit.js';
 import * as list from './list.js';
 import * as update from './update.js';
 
 export default function (_: any) {
-  _.command([list, create, edit, update])
+  _.command([list, create, edit, update, dryRun])
     .middleware([useAppConfig, useInstanceConnector, useAvailabilityChecker])
     .demandCommand(1, 'You need at least one command before moving on');
 }

--- a/src/graphql/doWebhookDryRun.ts
+++ b/src/graphql/doWebhookDryRun.ts
@@ -1,0 +1,12 @@
+/* eslint-disable import/prefer-default-export */
+export const doWebhookDryRun = /* GraphQL */ `
+  mutation doWebhookDryRun($objectId: ID!, $query: String!) {
+    webhookDryRun(objectId: $objectId, query: $query) {
+      payload
+      errors {
+        field
+        message
+      }
+    }
+  }
+`;

--- a/src/types.ts
+++ b/src/types.ts
@@ -91,6 +91,11 @@ export interface Open extends BaseOptions {
   resource?: string;
 }
 
+export interface WebhookDryRun extends BaseOptions {
+  objectId?: string;
+  query?: string;
+}
+
 export interface Environment {
   name: string;
   key: string;


### PR DESCRIPTION
## I want to merge this PR because 

- it introduces `webhook dry-run` command

## Related (issues, PRs, topics)

- NA

## Steps to test feature

- `saleor webhook dry-run`
- `saleor webhook dry-run --object-id='UHJvZHVjdDo3Mg=='`
- `saleor webhook dry-run --query='subscription { event { ... on ProductCreated { product { id name } } } }'`

## I have:

- [ ] Tested it locally and it doesn't break existing features
- [ ] Added documentation if public changes are introduced
- [ ] Added tests for my code
