### PR TITLE
Fix `saleor app` folder validation when mjs extension is used

### DIFF
--- a/src/lib/common.ts
+++ b/src/lib/common.ts
@@ -218,7 +218,9 @@ export const verifyIsSaleorAppDirectory = async (argv: any) => {
 
   // check if this is a Next.js app
   const isNodeApp = await fs.pathExists('package.json');
-  const isNextApp = await fs.pathExists('next.config.js');
+  const isNextApp =
+    (await fs.pathExists('next.config.js')) ||
+    (await fs.pathExists('next.config.mjs'));
 
   if (!isTunnel) {
     return {};


### PR DESCRIPTION
## I want to merge this PR because 

It fixes saleor app folder validation when `.mjs` extension is used (e.g. `next.config.mjs` instead of `next.config.js`)

## Steps to test feature

- Run `saleor app tunnel` in folder with app that uses `next.config.mjs`

## I have:

- [x] Tested it locally and it doesn't break existing features
- [ ] Added documentation if public changes are introduced
- [ ] Added tests for my code
