### PR TITLE
Revert `oclif` to `1.x`

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "homepage": "https://github.com/saleor/saleor-cli#readme",
   "bugs": "https://github.com/saleor/saleor-cli/issues",
   "bin": {
-    "saleor": "./dist/saleor.js"
+    "seor": "./dist/saleor.js"
   },
   "scripts": {
     "prepublishOnly": "rm -rf ./package && pnpm build && clean-publish --fields dependencies && node -e \"let pkg=require('./package/package.json'); pkg.dependencies = { 'got': '^12.4.1' }; require('fs').writeFileSync('./package/package.json', JSON.stringify(pkg, null, 2));\"",
@@ -35,8 +35,8 @@
   "author": "Saleor",
   "license": "BSD 3-Clause",
   "devDependencies": {
-    "@graphql-codegen/cli": "^3.0.0",
-    "@graphql-codegen/typescript-document-nodes": "^3.0.0",
+    "@graphql-codegen/cli": "^3.1.0",
+    "@graphql-codegen/typescript-document-nodes": "^3.0.1",
     "@types/cli-progress": "^3.11.0",
     "@types/debug": "^4.1.7",
     "@types/detect-port": "^1.3.2",
@@ -75,7 +75,7 @@
   },
   "dependencies": {
     "@mobily/ts-belt": "^3.13.1",
-    "@oclif/core": "^2.2.1",
+    "@oclif/core": "^1.26.2",
     "@sentry/node": "^7.38.0",
     "@types/lodash.isempty": "^4.4.7",
     "chalk": "^5.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,10 +4,10 @@ overrides:
   uuid: 8.3.2
 
 specifiers:
-  '@graphql-codegen/cli': ^3.0.0
-  '@graphql-codegen/typescript-document-nodes': ^3.0.0
+  '@graphql-codegen/cli': ^3.1.0
+  '@graphql-codegen/typescript-document-nodes': ^3.0.1
   '@mobily/ts-belt': ^3.13.1
-  '@oclif/core': ^2.2.1
+  '@oclif/core': ^1.26.2
   '@sentry/node': ^7.38.0
   '@types/cli-progress': ^3.11.0
   '@types/debug': ^4.1.7
@@ -85,7 +85,7 @@ specifiers:
 
 dependencies:
   '@mobily/ts-belt': 3.13.1
-  '@oclif/core': 2.2.1
+  '@oclif/core': 1.26.2
   '@sentry/node': 7.38.0
   '@types/lodash.isempty': 4.4.7
   chalk: 5.2.0
@@ -127,8 +127,8 @@ dependencies:
   yargs: 17.7.0
 
 devDependencies:
-  '@graphql-codegen/cli': 3.0.0_4gedfhnzx2o43hzpbc7lgo364i
-  '@graphql-codegen/typescript-document-nodes': 3.0.0_graphql@16.6.0
+  '@graphql-codegen/cli': 3.1.0_4gedfhnzx2o43hzpbc7lgo364i
+  '@graphql-codegen/typescript-document-nodes': 3.0.1_graphql@16.6.0
   '@types/cli-progress': 3.11.0
   '@types/debug': 4.1.7
   '@types/detect-port': 1.3.2
@@ -1248,8 +1248,8 @@ packages:
       - supports-color
     dev: true
 
-  /@graphql-codegen/cli/3.0.0_4gedfhnzx2o43hzpbc7lgo364i:
-    resolution: {integrity: sha512-16nuFabHCfPQ/d+v52OvR1ueL8eiJvS/nRuvuEV8d9T1fkborHKRw4lhyKVebu9izFBs6G0CvVCLhgVzQwHSLw==}
+  /@graphql-codegen/cli/3.1.0_4gedfhnzx2o43hzpbc7lgo364i:
+    resolution: {integrity: sha512-MUYyHkh/n8XVuONk7AYvJV/ObZDlPGwyevl8ch21jNFNj2M5PM39WViHKmIYwVw2n4fDmoh3BNdaeHQs1wb4HA==}
     hasBin: true
     peerDependencies:
       graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
@@ -1257,8 +1257,8 @@ packages:
       '@babel/generator': 7.21.1
       '@babel/template': 7.20.7
       '@babel/types': 7.21.0
-      '@graphql-codegen/core': 3.0.0_graphql@16.6.0
-      '@graphql-codegen/plugin-helpers': 4.0.0_graphql@16.6.0
+      '@graphql-codegen/core': 3.1.0_graphql@16.6.0
+      '@graphql-codegen/plugin-helpers': 4.1.0_graphql@16.6.0
       '@graphql-tools/apollo-engine-loader': 7.3.26_dsrot7vgr22owbcoisakchg2na
       '@graphql-tools/code-file-loader': 7.3.21_graphql@16.6.0
       '@graphql-tools/git-loader': 7.2.20_graphql@16.6.0
@@ -1269,7 +1269,7 @@ packages:
       '@graphql-tools/prisma-loader': 7.2.64_dsrot7vgr22owbcoisakchg2na
       '@graphql-tools/url-loader': 7.17.13_dsrot7vgr22owbcoisakchg2na
       '@graphql-tools/utils': 9.2.1_graphql@16.6.0
-      '@whatwg-node/fetch': 0.6.9_@types+node@18.14.0
+      '@whatwg-node/fetch': 0.8.1_@types+node@18.14.0
       chalk: 4.1.2
       chokidar: 3.5.3
       cosmiconfig: 7.1.0
@@ -1304,20 +1304,20 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@graphql-codegen/core/3.0.0_graphql@16.6.0:
-    resolution: {integrity: sha512-WUfAUTmUcgeHPR7F5ZQqaBqJLJb5+3Lvp6v9SrnupKOFed+Q3u8CvZL6sPTvDpqqW8Ucjy59DEZqumPLp99pdQ==}
+  /@graphql-codegen/core/3.1.0_graphql@16.6.0:
+    resolution: {integrity: sha512-DH1/yaR7oJE6/B+c6ZF2Tbdh7LixF1K8L+8BoSubjNyQ8pNwR4a70mvc1sv6H7qgp6y1bPQ9tKE+aazRRshysw==}
     peerDependencies:
       graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
     dependencies:
-      '@graphql-codegen/plugin-helpers': 4.0.0_graphql@16.6.0
+      '@graphql-codegen/plugin-helpers': 4.1.0_graphql@16.6.0
       '@graphql-tools/schema': 9.0.16_graphql@16.6.0
       '@graphql-tools/utils': 9.2.1_graphql@16.6.0
       graphql: 16.6.0
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: true
 
-  /@graphql-codegen/plugin-helpers/4.0.0_graphql@16.6.0:
-    resolution: {integrity: sha512-vgNGTanT36hC4RAC/LAThMEjDvnu3WCyx6MtKZcPUtfCWFxbUAr88+OarGl1LAEiOef0agIREC7tIBXCqjKkJA==}
+  /@graphql-codegen/plugin-helpers/4.1.0_graphql@16.6.0:
+    resolution: {integrity: sha512-xvSHJb9OGb5CODIls0AI1rCenLz+FuiaNPCsfHMCNsLDjOZK2u0jAQ9zUBdc/Wb+21YXZujBCc0Vm1QX+Zz0nw==}
     peerDependencies:
       graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
     dependencies:
@@ -1327,30 +1327,30 @@ packages:
       graphql: 16.6.0
       import-from: 4.0.0
       lodash: 4.17.21
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: true
 
-  /@graphql-codegen/typescript-document-nodes/3.0.0_graphql@16.6.0:
-    resolution: {integrity: sha512-IxBqVcFw+8wRqbs4Jd/WkoCT0PnFst1Qq0JsDEGFoqNnc5Bjs+BS5g3OYvSJTP04QUi6G8iTKr91FgEUubfI7Q==}
+  /@graphql-codegen/typescript-document-nodes/3.0.1_graphql@16.6.0:
+    resolution: {integrity: sha512-5bTy5BJ8Ci+Pg9k5JscsjbE3rZalClLDntkL8sxfYSbW6Qth4ySG5D7wx5eBfKAVgqEkhKHNtwz6SsQ5CSys8A==}
     peerDependencies:
       graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
     dependencies:
-      '@graphql-codegen/plugin-helpers': 4.0.0_graphql@16.6.0
-      '@graphql-codegen/visitor-plugin-common': 3.0.0_graphql@16.6.0
+      '@graphql-codegen/plugin-helpers': 4.1.0_graphql@16.6.0
+      '@graphql-codegen/visitor-plugin-common': 3.0.1_graphql@16.6.0
       auto-bind: 4.0.0
       graphql: 16.6.0
-      tslib: 2.4.1
+      tslib: 2.5.0
     transitivePeerDependencies:
       - encoding
       - supports-color
     dev: true
 
-  /@graphql-codegen/visitor-plugin-common/3.0.0_graphql@16.6.0:
-    resolution: {integrity: sha512-ZoNlCmmkGClB137SpJT9og/nkihLN7Z4Ynl9Ir3OlbDuI20dbpyXsclpr9QGLcxEcfQeVfhGw9CooW7wZJJ8LA==}
+  /@graphql-codegen/visitor-plugin-common/3.0.1_graphql@16.6.0:
+    resolution: {integrity: sha512-Qek+Ywy094Km7Vc1TzKBN9ICvtYwPdqZUliPO77urMSveP+2+G2O9Tjx546dW4A1O6rhEfexbenc2DqTAe7iLQ==}
     peerDependencies:
       graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
     dependencies:
-      '@graphql-codegen/plugin-helpers': 4.0.0_graphql@16.6.0
+      '@graphql-codegen/plugin-helpers': 4.1.0_graphql@16.6.0
       '@graphql-tools/optimize': 1.3.1_graphql@16.6.0
       '@graphql-tools/relay-operation-optimizer': 6.5.17_graphql@16.6.0
       '@graphql-tools/utils': 9.2.1_graphql@16.6.0
@@ -1360,7 +1360,7 @@ packages:
       graphql: 16.6.0
       graphql-tag: 2.12.6_graphql@16.6.0
       parse-filepath: 1.0.2
-      tslib: 2.4.1
+      tslib: 2.5.0
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -1605,7 +1605,7 @@ packages:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
     dependencies:
       graphql: 16.6.0
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: true
 
   /@graphql-tools/prisma-loader/7.2.64_dsrot7vgr22owbcoisakchg2na:
@@ -1649,7 +1649,7 @@ packages:
       '@ardatan/relay-compiler': 12.0.0_graphql@16.6.0
       '@graphql-tools/utils': 9.2.1_graphql@16.6.0
       graphql: 16.6.0
-      tslib: 2.4.1
+      tslib: 2.5.0
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -1870,11 +1870,12 @@ packages:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.15.0
 
-  /@oclif/core/2.2.1:
-    resolution: {integrity: sha512-TxIFfccAwb8SiVADZWxIS/GG2bcw0yBDBBxzqBQl7jurfG0wQtdu6jLfHHdVGYaYyMKw1UVZTFFLtX8iwRTW/Q==}
+  /@oclif/core/1.26.2:
+    resolution: {integrity: sha512-6jYuZgXvHfOIc9GIaS4T3CIKGTjPmfAxuMcbCbMRKJJl4aq/4xeRlEz0E8/hz8HxvxZBGvN2GwAUHlrGWQVrVw==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@types/cli-progress': 3.11.0
+      '@oclif/linewrap': 1.0.0
+      '@oclif/screen': 3.0.4
       ansi-escapes: 4.3.2
       ansi-styles: 4.3.0
       cardinal: 2.1.1
@@ -1900,8 +1901,17 @@ packages:
       supports-hyperlinks: 2.3.0
       tslib: 2.5.0
       widest-line: 3.1.0
-      wordwrap: 1.0.0
       wrap-ansi: 7.0.0
+    dev: false
+
+  /@oclif/linewrap/1.0.0:
+    resolution: {integrity: sha512-Ups2dShK52xXa8w6iBWLgcjPJWjais6KPJQq3gQ/88AY6BXoTX+MIGFPrWQO1KLMiQfoTpcLnUwloN4brrVUHw==}
+    dev: false
+
+  /@oclif/screen/3.0.4:
+    resolution: {integrity: sha512-IMsTN1dXEXaOSre27j/ywGbBjrzx0FNd1XmuhCWCB9NTPrhWI1Ifbz+YLSEcstfQfocYsrbrIessxXb2oon4lA==}
+    engines: {node: '>=12.0.0'}
+    deprecated: Deprecated in favor of @oclif/core
     dev: false
 
   /@octokit/auth-token/3.0.3:
@@ -2246,6 +2256,7 @@ packages:
     resolution: {integrity: sha512-XhXhBv1R/q2ahF3BM7qT5HLzJNlIL0wbcGyZVjqOTqAybAnsLisd7gy1UCyIqpL+5Iv6XhlSyzjLCnI2sIdbCg==}
     dependencies:
       '@types/node': 18.14.0
+    dev: true
 
   /@types/cookie/0.4.1:
     resolution: {integrity: sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==}
@@ -2344,6 +2355,7 @@ packages:
 
   /@types/node/18.14.0:
     resolution: {integrity: sha512-5EWrvLmglK+imbCJY0+INViFWUHg1AHel1sq4ZVSfdcNqGy9Edv3UB9IIzzg+xPaUcAgZYcfVs2fBcwDeZzU0A==}
+    dev: true
 
   /@types/parse-json/4.0.0:
     resolution: {integrity: sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==}
@@ -2563,18 +2575,6 @@ packages:
     resolution: {integrity: sha512-WKj/lI4QjnLuPrim0cfO7i+HsDSXHxNv1y0CrJhdntuO3hxWZmnXCwNDnwOvry11OjRin6cgWNF+j/9Pn8TN4w==}
     dev: true
 
-  /@whatwg-node/fetch/0.6.9_@types+node@18.14.0:
-    resolution: {integrity: sha512-JfrBCJdMu9n9OARc0e/hPHcD98/8Nz1CKSdGYDg6VbObDkV/Ys30xe5i/wPOatYbxuvatj1kfWeHf7iNX3i17w==}
-    dependencies:
-      '@peculiar/webcrypto': 1.4.1
-      '@whatwg-node/node-fetch': 0.0.5_@types+node@18.14.0
-      busboy: 1.6.0
-      urlpattern-polyfill: 6.0.2
-      web-streams-polyfill: 3.2.1
-    transitivePeerDependencies:
-      - '@types/node'
-    dev: true
-
   /@whatwg-node/fetch/0.8.1_@types+node@18.14.0:
     resolution: {integrity: sha512-Fkd1qQHK2tAWxKlC85h9L86Lgbq3BzxMnHSnTsnzNZMMzn6Xi+HlN8/LJ90LxorhSqD54td+Q864LgwUaYDj1Q==}
     dependencies:
@@ -2585,17 +2585,6 @@ packages:
       web-streams-polyfill: 3.2.1
     transitivePeerDependencies:
       - '@types/node'
-    dev: true
-
-  /@whatwg-node/node-fetch/0.0.5_@types+node@18.14.0:
-    resolution: {integrity: sha512-hbccmaSZaItdsRuBKBEEhLoO+5oXJPxiyd0kG2xXd0Dh3Rt+vZn4pADHxuSiSHLd9CM+S2z4+IxlEGbWUgiz9g==}
-    peerDependencies:
-      '@types/node': ^18.0.6
-    dependencies:
-      '@types/node': 18.14.0
-      '@whatwg-node/events': 0.0.2
-      busboy: 1.6.0
-      tslib: 2.5.0
     dev: true
 
   /@whatwg-node/node-fetch/0.3.0_@types+node@18.14.0:
@@ -3107,7 +3096,7 @@ packages:
     resolution: {integrity: sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==}
     dependencies:
       pascal-case: 3.1.2
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: true
 
   /camelcase/5.3.1:
@@ -3127,7 +3116,7 @@ packages:
     resolution: {integrity: sha512-ds37W8CytHgwnhGGTi88pcPyR15qoNkOpYwmMMfnWqqWgESapLqvDx6huFjQ5vqWSn2Z06173XNA7LtMOeUh1A==}
     dependencies:
       no-case: 3.0.4
-      tslib: 2.4.1
+      tslib: 2.5.0
       upper-case-first: 2.0.2
     dev: true
 
@@ -3214,7 +3203,7 @@ packages:
       path-case: 3.0.4
       sentence-case: 3.0.4
       snake-case: 3.0.4
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: true
 
   /chardet/0.7.0:
@@ -3496,7 +3485,7 @@ packages:
     resolution: {integrity: sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==}
     dependencies:
       no-case: 3.0.4
-      tslib: 2.4.1
+      tslib: 2.5.0
       upper-case: 2.0.2
     dev: true
 
@@ -3825,7 +3814,7 @@ packages:
     resolution: {integrity: sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==}
     dependencies:
       no-case: 3.0.4
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: true
 
   /dot-prop/6.0.1:
@@ -5250,7 +5239,7 @@ packages:
     resolution: {integrity: sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==}
     dependencies:
       capital-case: 1.0.4
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: true
 
   /headers-polyfill/3.1.2:
@@ -5646,7 +5635,7 @@ packages:
   /is-lower-case/2.0.2:
     resolution: {integrity: sha512-bVcMJy4X5Og6VZfdOZstSexlEy20Sr0k/p/b2IlQJlfdKAQuMpiv5w2Ccxb8sKdRUNAG1PnHVHjFSdRDVS6NlQ==}
     dependencies:
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: true
 
   /is-map/2.0.2:
@@ -5781,7 +5770,7 @@ packages:
   /is-upper-case/2.0.2:
     resolution: {integrity: sha512-44pxmxAvnnAOwBg4tHPnkfvgjPwbc5QIsSstNU+YcJ1ovxVzCWpSGosPJOZh/a1tdl81fbgnLc9LLv+x2ywbPQ==}
     dependencies:
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: true
 
   /is-weakmap/2.0.1:
@@ -6161,13 +6150,13 @@ packages:
   /lower-case-first/2.0.2:
     resolution: {integrity: sha512-EVm/rR94FJTZi3zefZ82fLWab+GX14LJN4HrWBcuo6Evmsl9hEfnqxgcHCKb9q+mNf6EVdsjx/qucYFIIB84pg==}
     dependencies:
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: true
 
   /lower-case/2.0.2:
     resolution: {integrity: sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==}
     dependencies:
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: true
 
   /lowercase-keys/3.0.0:
@@ -6445,7 +6434,7 @@ packages:
     resolution: {integrity: sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==}
     dependencies:
       lower-case: 2.0.2
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: true
 
   /node-abi/2.30.1:
@@ -6822,7 +6811,7 @@ packages:
     resolution: {integrity: sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==}
     dependencies:
       dot-case: 3.0.4
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: true
 
   /parent-module/1.0.1:
@@ -6879,7 +6868,7 @@ packages:
     resolution: {integrity: sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==}
     dependencies:
       no-case: 3.0.4
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: true
 
   /password-prompt/1.1.2:
@@ -6893,7 +6882,7 @@ packages:
     resolution: {integrity: sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==}
     dependencies:
       dot-case: 3.0.4
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: true
 
   /path-exists/4.0.0:
@@ -7636,7 +7625,7 @@ packages:
     resolution: {integrity: sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==}
     dependencies:
       no-case: 3.0.4
-      tslib: 2.4.1
+      tslib: 2.5.0
       upper-case-first: 2.0.2
     dev: true
 
@@ -7788,7 +7777,7 @@ packages:
     resolution: {integrity: sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==}
     dependencies:
       dot-case: 3.0.4
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: true
 
   /socks-proxy-agent/5.0.1:
@@ -7835,7 +7824,7 @@ packages:
   /sponge-case/1.0.1:
     resolution: {integrity: sha512-dblb9Et4DAtiZ5YSUZHLl4XhH4uK80GhAZrVXdN4O2P4gQ40Wa5UIOPUHlA/nFd2PLblBZWUioLMMAVrgpoYcA==}
     dependencies:
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: true
 
   /sprintf-js/1.0.3:
@@ -8050,7 +8039,7 @@ packages:
   /swap-case/2.0.2:
     resolution: {integrity: sha512-kc6S2YS/2yXbtkSMunBtKdah4VFETZ8Oh6ONSmSd9bRxhqTrtARUCBUiWXH3xVPpvR7tz2CSnkuXVE42EcGnMw==}
     dependencies:
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: true
 
   /tar-fs/2.1.1:
@@ -8127,7 +8116,7 @@ packages:
   /title-case/3.0.3:
     resolution: {integrity: sha512-e1zGYRvbffpcHIrnuqT0Dh+gEJtDaxDSoG4JAIpq4oDFyooziLBIiYQv0GBT4FUAnUop5uZ1hiIAj7oAF6sOCA==}
     dependencies:
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: true
 
   /tmp/0.0.33:
@@ -8224,10 +8213,6 @@ packages:
 
   /tslib/1.14.1:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
-
-  /tslib/2.4.1:
-    resolution: {integrity: sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==}
-    dev: true
 
   /tslib/2.5.0:
     resolution: {integrity: sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==}
@@ -8457,13 +8442,13 @@ packages:
   /upper-case-first/2.0.2:
     resolution: {integrity: sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==}
     dependencies:
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: true
 
   /upper-case/2.0.2:
     resolution: {integrity: sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==}
     dependencies:
-      tslib: 2.4.1
+      tslib: 2.5.0
     dev: true
 
   /uri-js/4.4.1:
@@ -8743,7 +8728,7 @@ packages:
   /wide-align/1.1.5:
     resolution: {integrity: sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==}
     dependencies:
-      string-width: 1.0.2
+      string-width: 4.2.3
     dev: true
 
   /widest-line/3.1.0:
@@ -8787,10 +8772,6 @@ packages:
     resolution: {integrity: sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==}
     engines: {node: '>=0.10.0'}
     dev: true
-
-  /wordwrap/1.0.0:
-    resolution: {integrity: sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==}
-    dev: false
 
   /wrap-ansi/6.2.0:
     resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}

--- a/src/cli/app/list.ts
+++ b/src/cli/app/list.ts
@@ -1,4 +1,4 @@
-import { ux as cli } from '@oclif/core';
+import { CliUx } from '@oclif/core';
 import chalk from 'chalk';
 import Debug from 'debug';
 import got from 'got';
@@ -26,6 +26,7 @@ export const desc = 'List installed Saleor Apps for an environment';
 export const handler = async (argv: Arguments<Options>) => {
   debug('command arguments: %O', obfuscateArgv(argv));
 
+  const { ux: cli } = CliUx;
   const headers = await Config.getBearerHeader();
 
   const { instance } = argv;

--- a/src/cli/backup/list.ts
+++ b/src/cli/backup/list.ts
@@ -1,4 +1,4 @@
-import { ux as cli } from '@oclif/core';
+import { CliUx } from '@oclif/core';
 import chalk from 'chalk';
 import Debug from 'debug';
 import { Arguments } from 'yargs';
@@ -28,6 +28,8 @@ export const handler = async (argv: Arguments<Options>) => {
     console.log(JSON.stringify(result, null, 2));
     return;
   }
+
+  const { ux: cli } = CliUx;
 
   cli.table(result, {
     name: {

--- a/src/cli/configure.ts
+++ b/src/cli/configure.ts
@@ -1,4 +1,4 @@
-import { ux as cli } from '@oclif/core';
+import { CliUx } from '@oclif/core';
 import chalk from 'chalk';
 import Debug from 'debug';
 import Enquirer from 'enquirer';
@@ -114,6 +114,7 @@ const chooseEnv = async (
 };
 
 export const configure = async (providedToken: string | undefined) => {
+  const { ux: cli } = CliUx;
   let token = providedToken;
   while (!token) token = await cli.prompt('Access Token', { type: 'mask' });
 

--- a/src/cli/dev/info.ts
+++ b/src/cli/dev/info.ts
@@ -3,7 +3,7 @@ import { createRequire } from 'node:module';
 import { run } from '../../lib/common.js';
 
 const require = createRequire(import.meta.url);
-const pkg = require('../../package.json');
+const pkg = require('../package.json');
 
 export const command = 'info';
 export const desc = 'Show env info for debugging';

--- a/src/cli/env/list.ts
+++ b/src/cli/env/list.ts
@@ -1,4 +1,4 @@
-import { ux as cli } from '@oclif/core';
+import { CliUx } from '@oclif/core';
 import chalk from 'chalk';
 import Debug from 'debug';
 import { Arguments, CommandBuilder } from 'yargs';
@@ -39,6 +39,8 @@ export const handler = async (argv: Arguments) => {
     console.log(JSON.stringify(result, null, 2));
     return;
   }
+
+  const { ux: cli } = CliUx;
 
   cli.table(
     result,

--- a/src/cli/info.ts
+++ b/src/cli/info.ts
@@ -1,6 +1,6 @@
 import { createRequire } from 'node:module';
 
-import { ux as cli } from '@oclif/core';
+import { CliUx } from '@oclif/core';
 import chalk from 'chalk';
 import Debug from 'debug';
 import type { CommandBuilder } from 'yargs';
@@ -46,6 +46,8 @@ export const handler = async (): Promise<void> => {
   );
 
   console.log('\n');
+
+  const { ux: cli } = CliUx;
 
   cli.url(chalk.blue('Website - https://saleor.io/'), 'https://saleor.io/');
   cli.url(

--- a/src/cli/job/list.ts
+++ b/src/cli/job/list.ts
@@ -1,4 +1,4 @@
-import { ux as cli } from '@oclif/core';
+import { CliUx } from '@oclif/core';
 import chalk from 'chalk';
 import Debug from 'debug';
 import { Arguments, CommandBuilder } from 'yargs';
@@ -29,6 +29,8 @@ export const handler = async (argv: Arguments<Options>) => {
     console.log(JSON.stringify(result, null, 2));
     return;
   }
+
+  const { ux: cli } = CliUx;
 
   cli.table(result, {
     type: {

--- a/src/cli/login.ts
+++ b/src/cli/login.ts
@@ -1,4 +1,4 @@
-import { ux as cli } from '@oclif/core';
+import { CliUx } from '@oclif/core';
 import chalk from 'chalk';
 import crypto from 'crypto';
 import Debug from 'debug';
@@ -43,6 +43,7 @@ export const builder: CommandBuilder = (_) =>
 
 export const handler = async (argv: Arguments<BaseOptions>) => {
   if (argv.headless) {
+    const { ux: cli } = CliUx;
     let { token } = argv;
     while (!token)
       token = await cli.prompt(

--- a/src/cli/organization/list.ts
+++ b/src/cli/organization/list.ts
@@ -1,4 +1,4 @@
-import { ux as cli } from '@oclif/core';
+import { CliUx } from '@oclif/core';
 import { format } from 'date-fns';
 import Debug from 'debug';
 import { Arguments } from 'yargs';
@@ -26,6 +26,8 @@ export const handler = async (argv: Arguments<Options>) => {
     console.log(JSON.stringify(result, null, 2));
     return;
   }
+
+  const { ux: cli } = CliUx;
 
   cli.table(result, {
     slug: { minWidth: 2 },

--- a/src/cli/project/list.ts
+++ b/src/cli/project/list.ts
@@ -1,4 +1,4 @@
-import { ux as cli } from '@oclif/core';
+import { CliUx } from '@oclif/core';
 import chalk from 'chalk';
 import Debug from 'debug';
 import { Arguments } from 'yargs';
@@ -20,6 +20,8 @@ export const handler = async (argv: Arguments<Options>) => {
     console.log(JSON.stringify(result, null, 2));
     return;
   }
+
+  const { ux: cli } = CliUx;
 
   cli.table(result, {
     slug: { minWidth: 2 },

--- a/src/cli/webhook/list.ts
+++ b/src/cli/webhook/list.ts
@@ -1,4 +1,4 @@
-import { ux as cli } from '@oclif/core';
+import { CliUx } from '@oclif/core';
 import chalk from 'chalk';
 import Debug from 'debug';
 import got from 'got';
@@ -62,6 +62,8 @@ export const handler = async (argv: Arguments<Options>) => {
     }
 
     console.log(chalk('\n App:', chalk.bold(appName), '\n'));
+
+    const { ux: cli } = CliUx;
 
     cli.table(webhooks, {
       id: {


### PR DESCRIPTION
## I want to merge this PR because 

- it reverts `oclif` to `1.x` as it messes up the bundling with `esbuild`

## Related (issues, PRs, topics)

- NA

## Steps to test feature

- NA

## I have:

- [X] Tested it locally and it doesn't break existing features
- [ ] Added documentation if public changes are introduced
- [ ] Added tests for my code
