### PR TITLE
Run only for Node 16+ and warn for odd versions

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -49,7 +49,7 @@ const debug = Debug('saleor-cli');
 const require = createRequire(import.meta.url);
 const pkg = require('../package.json');
 
-if (!semver.satisfies(process.versions.node, pkg.engines.node)) {
+if (!semver.satisfies(process.versions.node, '>= 16')) {
   console.error(
     `${chalk.red('ERROR')}: Saleor CLI requires Node.js 16.x or later`
   );


### PR DESCRIPTION
## I want to merge this PR because 

- it allows to run only for Node 16+ and warn for odd versions

## Related (issues, PRs, topics)

- NA

## Steps to test feature

- 

## I have:

- [X] Tested it locally and it doesn't break existing features
- [ ] Added documentation if public changes are introduced
- [ ] Added tests for my code
