### PR TITLE
Align the `env create` with Cloud speed up

### DIFF
--- a/src/cli/env/remove.ts
+++ b/src/cli/env/remove.ts
@@ -4,7 +4,12 @@ import type { Arguments, CommandBuilder } from 'yargs';
 
 import { Config } from '../../lib/config.js';
 import { API, DELETE, GET } from '../../lib/index.js';
-import { confirmRemoval, obfuscateArgv, waitForTask } from '../../lib/util.js';
+import {
+  confirmRemoval,
+  obfuscateArgv,
+  printlnSuccess,
+  waitForTask,
+} from '../../lib/util.js';
 import { useEnvironment } from '../../middleware/index.js';
 import { Options, Task } from '../../types.js';
 
@@ -31,17 +36,9 @@ export const handler = async (argv: Arguments<Options>) => {
   const proceed = await confirmRemoval(argv, `environment ${environment}`);
 
   if (proceed && environment) {
-    const result = (await DELETE(API.Environment, {
-      ...argv,
-      ...{ environment },
-    })) as Task;
-    await waitForTask(
-      argv,
-      result.task_id,
-      `Deleting environment: ${environment}`,
-      'Yay! Environment deleted!'
-    );
+    (await DELETE(API.Environment, { ...argv, ...{ environment } })) as Task;
     await removeCurrentEnvironment(environment);
+    printlnSuccess(`Environment ${environment} deleted`);
   }
 };
 

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -563,14 +563,14 @@ export const waitForTask = async (
 
     while (!succeed) {
       progress += 1;
-      await delay(2000);
+      await delay(400);
       spinner.text = `${spinnerText}...\n
     ${simpleProgress(progress)}\n
     ${messages[currentMsg]}`;
 
-      const nextMsg = progress % 5 === 0;
+      const nextMsg = progress % 20 === 0;
       if (nextMsg) {
-        currentMsg = progress % 3;
+        currentMsg = progress % 5;
         succeed = await checkIfJobSucceeded(taskId);
       }
     }


### PR DESCRIPTION
## I want to merge this PR because 

- it aligns the `env create` with the recent changes in Saleor Cloud regarding the environment creationg

## Related (issues, PRs, topics)

- NA

## Steps to test feature

- 

## I have:

- [x] Tested it locally and it doesn't break existing features
- [ ] Added documentation if public changes are introduced
- [ ] Added tests for my code
