### PR TITLE
Show custom page instead of redirect for Vercel & Github login

### DIFF
--- a/src/cli/github/login.ts
+++ b/src/cli/github/login.ts
@@ -10,7 +10,7 @@ import { GET } from 'retes/route';
 import type { CommandBuilder } from 'yargs';
 
 import { Config } from '../../lib/config.js';
-import { delay, openURL, printlnSuccess } from '../../lib/util.js';
+import { delay, openURL, printlnSuccess, successPage } from '../../lib/util.js';
 
 const debug = Debug('saleor-cli:github:login');
 
@@ -70,7 +70,16 @@ export const handler = async () => {
 
       emitter.emit('finish');
 
-      return Response.Redirect('https://cloud.saleor.io');
+      return {
+        body: successPage(
+          'You\'ve successfully authenticated Gitub with the Saleor CLI!'
+        ),
+        status: 200,
+        type: 'text/html',
+        headers: {
+          'Content-Type': 'text/html; charset=utf-8',
+        },
+      };
     }),
   ]);
   await app.start(port);

--- a/src/cli/login.ts
+++ b/src/cli/login.ts
@@ -16,7 +16,13 @@ import { Arguments, CommandBuilder } from 'yargs';
 import { Config, ConfigField, SaleorCLIPort } from '../lib/config.js';
 import { checkPort } from '../lib/detectPort.js';
 import { API, getAmplifyConfig, getEnvironment, POST } from '../lib/index.js';
-import { CannotOpenURLError, delay, openURL, println } from '../lib/util.js';
+import {
+  CannotOpenURLError,
+  delay,
+  openURL,
+  println,
+  successPage,
+} from '../lib/util.js';
 import { BaseOptions } from '../types.js';
 
 const RedirectURI = `http://localhost:${SaleorCLIPort}/`;
@@ -152,7 +158,7 @@ export const doLogin = async () => {
       emitter.emit('finish');
 
       return {
-        body: successPage,
+        body: successPage('You\'ve successfully logged into the Saleor CLI!'),
         status: 200,
         type: 'text/html',
         headers: {
@@ -222,38 +228,3 @@ const createConfig = async (
     await Config.set(name as ConfigField, value);
   }
 };
-
-const successPage = `
-<!DOCTYPE html>
-<html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <title>Saleor CLI</title>
-    <style>
-      html,
-      body {
-        height: 100%;
-      }
-
-      html {
-        display: table;
-        margin: auto;
-      }
-
-      body {
-        display: table-cell;
-        vertical-align: middle;
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto",
-          "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans",
-          "Helvetica Neue", sans-serif;
-        background-color: #f3f3f3;
-      }
-    </style>
-  </head>
-
-  <body>
-    <h1>You've successfully logged into the Saleor CLI!</h1>
-    <h3>You can close this tab and return to your terminal.</h3>
-  </body>
-</html>
-`;

--- a/src/cli/vercel/login.ts
+++ b/src/cli/vercel/login.ts
@@ -10,7 +10,7 @@ import { GET } from 'retes/route';
 import { Config, SaleorCLIPort } from '../../lib/config.js';
 import { checkPort } from '../../lib/detectPort.js';
 import { NoCommandBuilderSetup } from '../../lib/index.js';
-import { delay, openURL, printlnSuccess } from '../../lib/util.js';
+import { delay, openURL, printlnSuccess, successPage } from '../../lib/util.js';
 
 const RedirectURI = `http://localhost:${SaleorCLIPort}/vercel/callback`;
 
@@ -80,7 +80,16 @@ export const handler = async () => {
       // spinner.succeed(`You've successfully logged into Saleor Cloud!\n  Your access token has been safely stored, and you're ready to go`)
       emitter.emit('finish');
 
-      return Response.Redirect('https://cloud.saleor.io');
+      return {
+        body: successPage(
+          'You\'ve successfully authenticated Vercel with the Saleor CLI!'
+        ),
+        status: 200,
+        type: 'text/html',
+        headers: {
+          'Content-Type': 'text/html; charset=utf-8',
+        },
+      };
     }),
   ]);
   await app.start(SaleorCLIPort);

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -706,6 +706,41 @@ export const openURL = async (url: string) => {
   await open(url);
 };
 
+export const successPage = (message: string) => `
+  <!DOCTYPE html>
+  <html lang="en">
+    <head>
+      <meta charset="UTF-8" />
+      <title>Saleor CLI</title>
+      <style>
+        html,
+        body {
+          height: 100%;
+        }
+
+        html {
+          display: table;
+          margin: auto;
+        }
+
+        body {
+          display: table-cell;
+          vertical-align: middle;
+          font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto",
+            "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans",
+            "Helvetica Neue", sans-serif;
+          background-color: #f3f3f3;
+        }
+      </style>
+    </head>
+
+    <body>
+      <h1>${message}</h1>
+      <h3>You can close this tab and return to your terminal.</h3>
+    </body>
+  </html>
+  `;
+
 export const countries: { [key: string]: string } = {
   '': '',
   AF: 'Afghanistan',


### PR DESCRIPTION
## I want to merge this PR because 

- it shows a custom success page after successful integration with Vercel or Github

## Related (issues, PRs, topics)

- NA

## Steps to test the feature

- `saleor vercel login`
- `saleor github login`

## I have:

- [x] Tested it locally and it doesn't break existing features
- [ ] Added documentation if public changes are introduced
- [ ] Added tests for my code
