### PR TITLE
Add prompt and useEnvironment middleware for `saleor env populate`

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -424,7 +424,7 @@ Commands:
   saleor environment remove [key|environment]    Delete an environment
   saleor environment upgrade [key|environment]   Upgrade a Saleor version in a specific environment
   saleor environment clear <key|environment>     Clear database for environment
-  saleor environment populate <key|environment>  Populate database for environment
+  saleor environment populate [key|environment]  Populate database for environment
   saleor environment promote [key|environment]   Promote environment to production
 
 Options:
@@ -620,12 +620,12 @@ $ saleor environment populate --help
 Help output:
 
 ```
-saleor environment populate <key|environment>
+saleor environment populate [key|environment]
 
 Populate database for environment
 
 Positionals:
-  key, environment  key of the environment  [string] [required]
+  key, environment  key of the environment  [string]
 
 Options:
       --json             Output the data as JSON  [boolean]

--- a/src/cli/env/populate.ts
+++ b/src/cli/env/populate.ts
@@ -2,13 +2,16 @@ import Debug from 'debug';
 import type { Arguments, CommandBuilder } from 'yargs';
 
 import { API, GET } from '../../lib/index.js';
-import { obfuscateArgv, waitForTask } from '../../lib/util.js';
-import { useBlockingTasksChecker } from '../../middleware/index.js';
+import { confirmRemoval, obfuscateArgv, waitForTask } from '../../lib/util.js';
+import {
+  useBlockingTasksChecker,
+  useEnvironment,
+} from '../../middleware/index.js';
 import { Options } from '../../types.js';
 
 const debug = Debug('saleor-cli:env:populate');
 
-export const command = 'populate <key|environment>';
+export const command = 'populate [key|environment]';
 export const desc = 'Populate database for environment';
 
 export const builder: CommandBuilder = (_) =>
@@ -21,13 +24,23 @@ export const builder: CommandBuilder = (_) =>
 export const handler = async (argv: Arguments<Options>) => {
   debug('command arguments: %O', obfuscateArgv(argv));
 
-  const result = (await GET(API.PopulateDatabase, argv)) as any;
-  await waitForTask(
+  const { environment } = argv;
+
+  const proceed = await confirmRemoval(
     argv,
-    result.task_id,
-    `Populating database: ${argv.environment}`,
-    'Yay! Database populated!'
+    `environment ${environment}`,
+    'replace database with a sample for'
   );
+
+  if (proceed) {
+    const result = (await GET(API.PopulateDatabase, argv)) as any;
+    await waitForTask(
+      argv,
+      result.task_id,
+      `Populating database: ${argv.environment}`,
+      'Yay! Database populated!'
+    );
+  }
 };
 
-export const middlewares = [useBlockingTasksChecker];
+export const middlewares = [useEnvironment, useBlockingTasksChecker];

--- a/src/cli/env/remove.ts
+++ b/src/cli/env/remove.ts
@@ -3,12 +3,11 @@ import Debug from 'debug';
 import type { Arguments, CommandBuilder } from 'yargs';
 
 import { Config } from '../../lib/config.js';
-import { API, DELETE, GET } from '../../lib/index.js';
+import { API, DELETE } from '../../lib/index.js';
 import {
   confirmRemoval,
   obfuscateArgv,
   printlnSuccess,
-  waitForTask,
 } from '../../lib/util.js';
 import { useEnvironment } from '../../middleware/index.js';
 import { Options, Task } from '../../types.js';

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -613,13 +613,17 @@ export const showResult = (
 export const formatConfirm = (value: string) =>
   chalk.cyan(value ? 'yes' : 'no');
 
-export const confirmRemoval = async (argv: Options, name: string) => {
+export const confirmRemoval = async (
+  argv: Options,
+  name: string,
+  action = 'remove'
+) => {
   const { proceed } = (await Enquirer.prompt({
     type: 'confirm',
     name: 'proceed',
     initial: argv.force,
     skip: !!argv.force,
-    message: `You are going to remove ${name}. Continue`,
+    message: `You are going to ${action} ${name}. Continue`,
     format: formatConfirm,
   })) as { proceed: boolean };
 


### PR DESCRIPTION
## I want to merge this PR because 

- it adds a confirm prompt for `saleor env populate` command
- it adds `useEnvironment` middleware to allow to pick the environment in case of blank parameter or use environment name

## Related (issues, PRs, topics)

- NA

## Steps to test the feature

- `saleor env populate`

## I have:

- [x] Tested it locally and it doesn't break existing features
- [x] Added documentation if public changes are introduced
- [ ] Added tests for my code
