### PR TITLE
Increase timeout for storefront manifest test

### DIFF
--- a/test/functional/storefront/deploy.test.ts
+++ b/test/functional/storefront/deploy.test.ts
@@ -89,17 +89,21 @@ describe('storefront deploy', async () => {
     1000 * 60 * 10
   );
 
-  it('the deployed checkout returns the manifest', async () => {
-    const { vercel_token: VercelToken } = await Config.get();
+  it(
+    'the deployed checkout returns the manifest',
+    async () => {
+      const { vercel_token: VercelToken } = await Config.get();
 
-    if (!shouldMockTests) {
-      const vercel = new Vercel(VercelToken);
-      const { name: domain } = await vercel.getProjectDomain(checkoutName);
-      const manifest: Manifest = await got
-        .get(`https://${domain}/api/manifest`)
-        .json();
+      if (!shouldMockTests) {
+        const vercel = new Vercel(VercelToken);
+        const { name: domain } = await vercel.getProjectDomain(checkoutName);
+        const manifest: Manifest = await got
+          .get(`https://${domain}/api/manifest`)
+          .json();
 
-      expect(manifest.name).toBe('Checkout');
-    }
-  });
+        expect(manifest.name).toBe('Checkout');
+      }
+    },
+    1000 * 60
+  );
 });


### PR DESCRIPTION
## I want to merge this PR because 

- it increases timeout for the storefront deployment test as the Vercel deployment needs more time than the default timeout to return the manifest

## Related (issues, PRs, topics)

- NA

## Steps to test the feature

- `pnpm vitest run test/functional/storefront/deploy.test.ts    `

## I have:

- [ ] Tested it locally and it doesn't break existing features
- [ ] Added documentation if public changes are introduced
- [ ] Added tests for my code
