### PR TITLE
Use saleor-app-template as source of app examples

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1389,10 +1389,9 @@ Options:
       --json                            Output the data as JSON  [boolean]
       --short                           Output data as text  [boolean] [default: false]
   -u, --instance, --url  [string]
-      --dependencies, --deps  [boolean] [default: true]
-  -t, --template, --repo, --repository  [string] [default: "saleor/saleor-app-template"]
-  -b, --branch  [string] [default: "main"]
-  -e, --example  [string]
+  -t, --template, --repo, --repository  Template repository to start from  [string] [default: "saleor/saleor-app-template"]
+  -b, --branch                          Branch of the template repository  [string] [default: "main"]
+  -e, --example                         Use an Example App as a starter  [string]
   -V, --version                         Show version number  [boolean]
   -h, --help                            Show help  [boolean]
 ```

--- a/src/lib/download.ts
+++ b/src/lib/download.ts
@@ -1,9 +1,12 @@
+import Debug from 'debug';
 import fs from 'fs-extra';
 import GitURLParse from 'git-url-parse';
 import { join } from 'path';
 import { simpleGit } from 'simple-git';
 
 import { WrongGitURLError } from './util.js';
+
+const debug = Debug('saleor-cli:lib:download');
 
 const git = simpleGit();
 
@@ -18,15 +21,21 @@ export const gitCopy = async (repo: string, dest: string, ref = 'main') => {
   }
 };
 
-export const gitCopySHA = async (repo: string, dest: string, sha: string) => {
+export const gitCopySHA = async (
+  repo: string,
+  dest: string,
+  sha: string,
+  ref = 'main'
+) => {
   try {
     const { href: repoURL } = GitURLParse(repo);
-    await git.clone(repoURL, dest).cwd({ path: dest });
+    await git.clone(repoURL, dest, { '--branch': ref }).cwd({ path: dest });
     const target = join(process.cwd(), dest);
     await git.cwd({ path: target, root: true });
     await git.reset(['--hard', sha]);
     await fs.remove(`${dest}/.git`);
   } catch (error) {
+    debug(`gitCopySHA err: ${error}`);
     throw new WrongGitURLError(`Provided Git URL is invalid: ${repo}`);
   }
 };


### PR DESCRIPTION
## I want to merge this PR because 

- it drops https://github.com/saleor/app-examples if favor of changes the source of the ](https://github.com/saleor/saleor-app-template) as the source of examples

## Related (issues, PRs, topics)

- NA

## Steps to test the feature

- `saleor app create -e`

## I have:

- [ ] Tested it locally and it doesn't break existing features
- [ ] Added documentation if public changes are introduced
- [ ] Added tests for my code
