### PR TITLE
Sort for promptCompatibleVersion

### DIFF
--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -308,9 +308,15 @@ export const promptCompatibleVersion = async (argv: any, service = 'SANDBOX') =>
     'production service',
     'Select a Saleor service',
     async () =>
-      (await getSortedServices(argv)).filter(
-        ({ service_type: serviceType }: any) => serviceType === service
-      ),
+      (await getSortedServices(argv))
+        .filter(({ service_type: serviceType }: any) => serviceType === service)
+        .sort((a, b) =>
+          b.version
+            .replace(/\d+/g, (n: string) => +n + 100000)
+            .localeCompare(
+              a.version.replace(/\d+/g, (n: string) => +n + 100000)
+            )
+        ),
     (_: any) => ({
       name: `Saleor ${_.version} - ${_.display_name}`,
       value: _.name,


### PR DESCRIPTION
## I want to merge this PR because 

- it properly sorts the available Saleor versions for the `environment create` command 

## Related (issues, PRs, topics)

- NA

## Steps to test the feature

- `saleor env create`

## I have:

- [x] Tested it locally and it doesn't break existing features
- [ ] Added documentation if public changes are introduced
- [ ] Added tests for my code
