### PR TITLE
Remove deployment prompt from `env create`

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -508,7 +508,6 @@ Options:
       --email            specify the dashboard access email  [string]
       --login            specify the api Basic Auth login  [string]
       --pass             specify the api Basic Auth password  [string]
-      --deploy           specify Vercel deployment  [boolean]
       --restore_from     specify snapshot id to restore database from  [string]
   -V, --version          Show version number  [boolean]
   -h, --help             Show help  [boolean]

--- a/src/cli/env/create.ts
+++ b/src/cli/env/create.ts
@@ -9,7 +9,6 @@ import { Arguments, CommandBuilder } from 'yargs';
 import { API, GET, POST, PUT } from '../../lib/index.js';
 import {
   contentBox,
-  deploy,
   formatConfirm,
   obfuscateArgv,
   SaleorEnvironmentError,
@@ -33,7 +32,6 @@ interface Options {
   domain: string;
   login?: string;
   pass?: string;
-  deploy: boolean;
   restore: boolean;
   restore_from: string;
   skipRestrict: boolean;
@@ -79,10 +77,6 @@ export const builder: CommandBuilder = (_) =>
       type: 'string',
       desc: 'specify the api Basic Auth password',
     })
-    .option('deploy', {
-      type: 'boolean',
-      desc: 'specify Vercel deployment',
-    })
     .option('restore_from', {
       type: 'string',
       desc: 'specify snapshot id to restore database from',
@@ -106,20 +100,6 @@ export const handler = async (argv: Arguments<Options>) => {
       const endpoint = `https://${result.domain}/graphql/`;
       await updateWebhook(endpoint);
     }
-  }
-
-  const { deployPrompt } = (await Enquirer.prompt({
-    type: 'confirm',
-    name: 'deployPrompt',
-    message: 'Deploy our react-storefront starter pack to Vercel',
-    format: formatConfirm,
-    initial: argv.deploy,
-    skip: !(argv.deploy === undefined),
-  })) as { deployPrompt: boolean };
-
-  if (deployPrompt) {
-    debug('deploying `react-storefront` to Vercel');
-    await deploy({ name: result.name, url: `https://${result.domain}` });
   }
 };
 

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -501,30 +501,6 @@ export const validatePresence = (value: string): boolean => {
   return true;
 };
 
-export const deploy = async ({ name, url }: { name: string; url: string }) => {
-  const params = {
-    'repository-url': 'https://github.com/saleor/react-storefront',
-    'project-name': name || 'my-react-storefront',
-    'repository-name': name || 'my-react-storefront',
-    env: 'NEXT_PUBLIC_API_URI',
-    envDescription: '\'NEXT_PUBLIC_API_URI\' is your GraphQL endpoint',
-    envLink: 'https://github.com/saleor/react-storefront',
-  };
-
-  const queryParams = new URLSearchParams(params);
-
-  contentBox([
-    '  To complete the deployment, open the following link in your browser and continue there: \n\n',
-    chalk.blue(`https://vercel.com/new/clone?${queryParams}\n\n`),
-    ` Use the following ${chalk.underline(
-      'Environment Variables'
-    )} for configuration:`,
-    `\n\n  ${chalk.gray('NEXT_PUBLIC_API_URI')}=${chalk.yellow(
-      `${url}/graphql/`
-    )}`,
-  ]);
-};
-
 export const checkIfJobSucceeded = async (taskId: string): Promise<boolean> => {
   const result = (await GET(API.TaskStatus, { task: taskId })) as any;
   return result.status === 'SUCCEEDED';


### PR DESCRIPTION
## I want to merge this PR because 

- it removes the outdated ability to deploy `react-storefront` starter to Vercel after successful environment creation 

## Related (issues, PRs, topics)

- https://github.com/saleor/saleor-cli/issues/532

## Steps to test the feature

- `saleor env create`

## I have:

- [x] Tested it locally and it doesn't break existing features
- [x] Added documentation if public changes are introduced
- [ ] Added tests for my code
