### PR TITLE
Add name prompt & examples for `backup create` command

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -674,7 +674,7 @@ saleor backup [command]
 
 Commands:
   saleor backup list [key|environment]    List backups of the environment
-  saleor backup create <name>             Create a new backup
+  saleor backup create [name]             Create a new backup
   saleor backup show [backup|backup-key]  Show a specific backup
   saleor backup remove <key|backup>       Remove the backup
   saleor backup restore [from]            Restore a specific backup
@@ -717,19 +717,21 @@ $ saleor backup create --help
 Help output:
 
 ```
-saleor backup create <name>
+saleor backup create [name]
 
 Create a new backup
-
-Positionals:
-  name  name for the new backup  [string] [required]
 
 Options:
       --json             Output the data as JSON  [boolean] [default: false]
       --short            Output data as text  [boolean] [default: false]
   -u, --instance, --url  Saleor instance to work with  [string]
+      --name             name for the new backup  [string]
   -V, --version          Show version number  [boolean]
   -h, --help             Show help  [boolean]
+
+Examples:
+  saleor backup create
+  saleor backup create my-backup --environment=env-id-or-name
 ```
 
 #### backup show

--- a/src/cli/backup/create.ts
+++ b/src/cli/backup/create.ts
@@ -1,25 +1,43 @@
 import Debug from 'debug';
+import Enquirer from 'enquirer';
 import type { Arguments, CommandBuilder } from 'yargs';
 
 import { API, POST } from '../../lib/index.js';
-import { obfuscateArgv, showResult, waitForTask } from '../../lib/util.js';
+import {
+  obfuscateArgv,
+  showResult,
+  validateLength,
+  waitForTask,
+} from '../../lib/util.js';
 
 const debug = Debug('saleor-cli:backup:create');
 
-export const command = 'create <name>';
+export const command = 'create [name]';
 export const desc = 'Create a new backup';
 
 export const builder: CommandBuilder = (_) =>
-  _.positional('name', {
+  _.option('name', {
     type: 'string',
     demandOption: false,
     desc: 'name for the new backup',
-  });
+  })
+    .example('saleor backup create', '')
+    .example('saleor backup create my-backup --environment=env-id-or-name', '');
 
 export const handler = async (argv: Arguments<any>) => {
   debug('command arguments: %O', obfuscateArgv(argv));
 
-  const { name } = argv;
+  const { name } = (await Enquirer.prompt([
+    {
+      type: 'input',
+      name: 'name',
+      message: 'Backup name',
+      initial: argv.name,
+      required: true,
+      skip: !!argv.name,
+      validate: (value) => validateLength(value, 255),
+    },
+  ])) as { name: string };
 
   debug(`Using the name: ${name}`);
 


### PR DESCRIPTION
## I want to merge this PR because 

- it allows entering backup name interactively 
- it adds examples 

## Related (issues, PRs, topics)

- NA

## Steps to test feature

- `saleor backup create`

## I have:

- [x] Tested it locally and it doesn't break existing features
- [x] Added documentation if public changes are introduced
- [ ] Added tests for my code
