### PR TITLE
Remove access prompt for `env create`, update options & examples

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -507,12 +507,17 @@ Options:
       --database         specify how to populate the database  [string]
       --saleor           specify the Saleor version  [string]
       --domain           specify the domain for the environment  [string]
-      --email            specify the dashboard access email  [string]
       --login            specify the api Basic Auth login  [string]
       --pass             specify the api Basic Auth password  [string]
-      --restore_from     specify snapshot id to restore database from  [string]
+      --restore-from     specify snapshot id to restore database from  [string]
+      --skip-restrict    skip Basic Auth restriction prompt  [boolean]
   -V, --version          Show version number  [boolean]
   -h, --help             Show help  [boolean]
+
+Examples:
+  saleor env create my-environment
+  saleor env create my-environment --project=project-name --database=sample --saleor=saleor-master-staging --domain=project-domain --skip-restrict
+  saleor env create my-environment --organization=organization-slug --project=project-name --database=sample --saleor=saleor-master-staging --domain=project-domain --skip-restrict
 ```
 
 #### environment switch

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -85,8 +85,6 @@ export const API: Record<string, DefaultURLPath> = {
     `organizations/${_.organization}/environments/${_.environment}/populate-database`,
   ClearDatabase: (_) =>
     `organizations/${_.organization}/environments/${_.environment}/clear-database`,
-  SetAdminAccount: (_) =>
-    `organizations/${_.organization}/environments/${_.environment}/set-admin-account`,
   Job: (_) =>
     `organizations/${_.organization}/environments/${_.environment}/jobs`,
   TaskStatus: (_) => `service/task-status/${_.task}`,

--- a/test/functional/environment/create.test.ts
+++ b/test/functional/environment/create.test.ts
@@ -23,9 +23,7 @@ describe('create new environment', async () => {
         '--database=sample',
         '--saleor=saleor-master-staging',
         `--domain=${envName}`,
-        '--email=test@example.com',
-        '--skipRestrict',
-        '--deploy',
+        '--skip-restrict',
         `--organization=${testOrganization}`,
       ];
       const { exitCode } = await trigger(command, params, {});


### PR DESCRIPTION
## I want to merge this PR because 

- it removes `email` option used to setup the Dashboard acccess
- it adds example commands
- it adds `skip-restrict` to the options list and unifies options naming

## Related (issues, PRs, topics)

- #649 

## Steps to test feature

- `saleor env create my-env-name`

## I have:

- [x] Tested it locally and it doesn't break existing features
- [x] Added documentation if public changes are introduced
- [x] Added tests for my code
