### PR TITLE
Upload sourcemaps to Sentry after publish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -146,3 +146,6 @@ package/
 
 .type-coverage/
 coverage-ts/
+
+# Sentry Auth Token
+.sentryclirc

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "prepublishOnly": "rm -rf ./package && pnpm build && clean-publish --fields dependencies && node -e \"let pkg=require('./package/package.json'); pkg.dependencies = { 'got': '^12.4.1' }; require('fs').writeFileSync('./package/package.json', JSON.stringify(pkg, null, 2));\"",
-    "postpublish": "",
+    "postpublish": "pnpm sentry:sourcemaps",
     "bundle": "esbuild src/cli.ts --sourcemap --bundle --minify --outfile=dist/saleor.js --platform=node --format=esm --target=node16 --banner:js=\"import { createRequire } from 'module';const require = createRequire(import.meta.url);import { dirname } from 'path'; import { fileURLToPath } from 'url'; const __dirname = dirname(fileURLToPath(import.meta.url));\" --out-extension:.js=.js --define:process.env.NODE_ENV=\\\"production\\\"",
     "build": "pnpm bundle",
     "watch-generate": "graphql-codegen -w",
@@ -24,7 +24,8 @@
     "prepare": "husky install",
     "typecov": "type-coverage --cache",
     "typecov-report": "typescript-coverage-report",
-    "release": "release-it --dry-run"
+    "release": "release-it --dry-run",
+    "sentry:sourcemaps": "sentry-cli sourcemaps inject --org saleor --project saleor-cli ./dist && sentry-cli sourcemaps upload --release $npm_package_version --dist $npm_package_version/$npm_package_name --org saleor --project saleor-cli ./dist"
   },
   "files": [
     "dist/saleor.js",
@@ -36,6 +37,7 @@
   "devDependencies": {
     "@graphql-codegen/cli": "^5.0.0",
     "@graphql-codegen/typescript-document-nodes": "^4.0.1",
+    "@sentry/cli": "^2.19.4",
     "@types/cli-progress": "^3.11.0",
     "@types/debug": "^4.1.8",
     "@types/detect-port": "^1.3.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -142,6 +142,9 @@ devDependencies:
   '@graphql-codegen/typescript-document-nodes':
     specifier: ^4.0.1
     version: 4.0.1(graphql@16.7.1)
+  '@sentry/cli':
+    specifier: ^2.19.4
+    version: 2.19.4
   '@types/cli-progress':
     specifier: ^3.11.0
     version: 3.11.0
@@ -2132,6 +2135,22 @@ packages:
       '@sentry/utils': 7.60.0
       tslib: 2.6.0
     dev: false
+
+  /@sentry/cli@2.19.4:
+    resolution: {integrity: sha512-wsSr2O/GVgr/i+DYtie+DNhODyI+HL7F5/0t1HwWMjHJWm4+5XTEauznYgbh2mewkzfUk9+t0CPecA82lEgspg==}
+    engines: {node: '>= 10'}
+    hasBin: true
+    requiresBuild: true
+    dependencies:
+      https-proxy-agent: 5.0.1
+      node-fetch: 2.6.12
+      progress: 2.0.3
+      proxy-from-env: 1.1.0
+      which: 2.0.2
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+    dev: true
 
   /@sentry/core@7.60.0:
     resolution: {integrity: sha512-B02OlFMoqdkfDZlbQfmk7tL2vObShofk7ySd/7mp+oRdUuCvX0tyrGlwI87YJvd8YWSZOCKINs3aVYivw/b6gg==}


### PR DESCRIPTION
## I want to merge this PR because 

- it pushes source maps to Sentry in post publish hook

## Related (issues, PRs, topics)

- NA

## Steps to test feature

- `pnpm publish`

## I have:

- [x] Tested it locally and it doesn't break existing features
- [ ] Added documentation if public changes are introduced
- [ ] Added tests for my code
