### PR TITLE
Commands to trigger updates on the environment

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -78,15 +78,18 @@ for more information, find the documentation at https://saleor.io
   * [organization permissions](#organization-permissions)
   * [organization switch](#organization-switch)
 * [environment](#environment)
-  * [environment show](#environment-show)
-  * [environment list](#environment-list)
-  * [environment create](#environment-create)
-  * [environment switch](#environment-switch)
-  * [environment remove](#environment-remove)
-  * [environment upgrade](#environment-upgrade)
+  * [environment auth](#environment-auth)
   * [environment clear](#environment-clear)
+  * [environment create](#environment-create)
+  * [environment list](#environment-list)
+  * [environment maintenance](#environment-maintenance)
   * [environment populate](#environment-populate)
   * [environment promote](#environment-promote)
+  * [environment remove](#environment-remove)
+  * [environment show](#environment-show)
+  * [environment switch](#environment-switch)
+  * [environment update](#environment-update)
+  * [environment upgrade](#environment-upgrade)
 * [backup](#backup)
   * [backup list](#backup-list)
   * [backup create](#backup-create)
@@ -447,15 +450,18 @@ Help output:
 saleor environment [command]
 
 Commands:
-  saleor environment show [key|environment]      Show a specific environment
-  saleor environment list                        List environments
-  saleor environment create [name]               Create a new environment
-  saleor environment switch [key|environment]    Make the provided environment the default one
-  saleor environment remove [key|environment]    Delete an environment
-  saleor environment upgrade [key|environment]   Upgrade a Saleor version in a specific environment
-  saleor environment clear <key|environment>     Clear database for environment
-  saleor environment populate [key|environment]  Populate database for environment
-  saleor environment promote [key|environment]   Promote environment to production
+  saleor environment auth [key|environment]         Manage basic auth for a specific environment
+  saleor environment clear <key|environment>        Clear database for environment
+  saleor environment create [name]                  Create a new environment
+  saleor environment list                           List environments
+  saleor environment maintenance [key|environment]  Enable or disable maintenance mode in a specific environment
+  saleor environment populate [key|environment]     Populate database for environment
+  saleor environment promote [key|environment]      Promote environment to production
+  saleor environment remove [key|environment]       Delete an environment
+  saleor environment show [key|environment]         Show a specific environment
+  saleor environment switch [key|environment]       Make the provided environment the default one
+  saleor environment update [key|environment]       Update name of the environment
+  saleor environment upgrade [key|environment]      Upgrade a Saleor version in a specific environment
 
 Options:
       --json             Output the data as JSON  [boolean] [default: false]
@@ -465,48 +471,59 @@ Options:
   -h, --help             Show help  [boolean]
 ```
 
-#### environment show
+#### environment auth
 
 ```sh
-$ saleor environment show --help
+$ saleor environment auth --help
 ```
 
 Help output:
 
 ```
-saleor environment show [key|environment]
+saleor environment auth [key|environment]
 
-Show a specific environment
+Manage basic auth for a specific environment
 
 Positionals:
   key, environment  key of the environment  [string]
 
 Options:
-      --json             Output the data as JSON  [boolean] [default: false]
-      --short            Output data as text  [boolean] [default: false]
-  -u, --instance, --url  Saleor instance to work with  [string]
-  -V, --version          Show version number  [boolean]
-  -h, --help             Show help  [boolean]
+      --json              Output the data as JSON  [boolean] [default: false]
+      --short             Output data as text  [boolean] [default: false]
+  -u, --instance, --url   Saleor instance to work with  [string]
+      --login             basic auth login of the environment  [string]
+      --password, --pass  basic auth password of the environment  [string]
+      --disable           disable basic auth for the environment  [boolean]
+  -V, --version           Show version number  [boolean]
+  -h, --help              Show help  [boolean]
+
+Examples:
+  saleor env auth
+  saleor env auth my-environment
+  saleor env auth my-environment --login=saleor --password=saleor
+  saleor env auth my-environment --disable
 ```
 
-#### environment list
+#### environment clear
 
 ```sh
-$ saleor environment list --help
+$ saleor environment clear --help
 ```
 
 Help output:
 
 ```
-saleor environment list
+saleor environment clear <key|environment>
 
-List environments
+Clear database for environment
+
+Positionals:
+  key, environment  key of the environment  [string] [required]
 
 Options:
       --json             Output the data as JSON  [boolean] [default: false]
       --short            Output data as text  [boolean] [default: false]
   -u, --instance, --url  Saleor instance to work with  [string]
-      --extended         show extended table  [boolean] [default: false]
   -V, --version          Show version number  [boolean]
   -h, --help             Show help  [boolean]
 ```
@@ -548,18 +565,40 @@ Examples:
   saleor env create my-environment --organization=organization-slug --project=project-name --database=sample --saleor=saleor-master-staging --domain=project-domain --skip-restrict
 ```
 
-#### environment switch
+#### environment list
 
 ```sh
-$ saleor environment switch --help
+$ saleor environment list --help
 ```
 
 Help output:
 
 ```
-saleor environment switch [key|environment]
+saleor environment list
 
-Make the provided environment the default one
+List environments
+
+Options:
+      --json             Output the data as JSON  [boolean] [default: false]
+      --short            Output data as text  [boolean] [default: false]
+  -u, --instance, --url  Saleor instance to work with  [string]
+      --extended         show extended table  [boolean] [default: false]
+  -V, --version          Show version number  [boolean]
+  -h, --help             Show help  [boolean]
+```
+
+#### environment maintenance
+
+```sh
+$ saleor environment maintenance --help
+```
+
+Help output:
+
+```
+saleor environment maintenance [key|environment]
+
+Enable or disable maintenance mode in a specific environment
 
 Positionals:
   key, environment  key of the environment  [string]
@@ -568,81 +607,16 @@ Options:
       --json             Output the data as JSON  [boolean] [default: false]
       --short            Output data as text  [boolean] [default: false]
   -u, --instance, --url  Saleor instance to work with  [string]
+      --enable           enable maintenance mode  [boolean]
+      --disable          disable maintenance mode  [boolean]
   -V, --version          Show version number  [boolean]
   -h, --help             Show help  [boolean]
-```
 
-#### environment remove
-
-```sh
-$ saleor environment remove --help
-```
-
-Help output:
-
-```
-saleor environment remove [key|environment]
-
-Delete an environment
-
-Positionals:
-  key, environment  key of the environment  [string]
-
-Options:
-      --json             Output the data as JSON  [boolean] [default: false]
-      --short            Output data as text  [boolean] [default: false]
-  -u, --instance, --url  Saleor instance to work with  [string]
-      --force            skip confirmation prompt  [boolean]
-  -V, --version          Show version number  [boolean]
-  -h, --help             Show help  [boolean]
-```
-
-#### environment upgrade
-
-```sh
-$ saleor environment upgrade --help
-```
-
-Help output:
-
-```
-saleor environment upgrade [key|environment]
-
-Upgrade a Saleor version in a specific environment
-
-Positionals:
-  key, environment  key of the environment  [string]
-
-Options:
-      --json             Output the data as JSON  [boolean] [default: false]
-      --short            Output data as text  [boolean] [default: false]
-  -u, --instance, --url  Saleor instance to work with  [string]
-  -V, --version          Show version number  [boolean]
-  -h, --help             Show help  [boolean]
-```
-
-#### environment clear
-
-```sh
-$ saleor environment clear --help
-```
-
-Help output:
-
-```
-saleor environment clear <key|environment>
-
-Clear database for environment
-
-Positionals:
-  key, environment  key of the environment  [string] [required]
-
-Options:
-      --json             Output the data as JSON  [boolean] [default: false]
-      --short            Output data as text  [boolean] [default: false]
-  -u, --instance, --url  Saleor instance to work with  [string]
-  -V, --version          Show version number  [boolean]
-  -h, --help             Show help  [boolean]
+Examples:
+  saleor env maintenance
+  saleor env maintenance my-environment
+  saleor env maintenance my-environment --enable
+  saleor env maintenance my-environment --disable
 ```
 
 #### environment populate
@@ -690,6 +664,133 @@ Options:
       --short            Output data as text  [boolean] [default: false]
   -u, --instance, --url  Saleor instance to work with  [string]
       --saleor           specify the Saleor version  [string]
+  -V, --version          Show version number  [boolean]
+  -h, --help             Show help  [boolean]
+```
+
+#### environment remove
+
+```sh
+$ saleor environment remove --help
+```
+
+Help output:
+
+```
+saleor environment remove [key|environment]
+
+Delete an environment
+
+Positionals:
+  key, environment  key of the environment  [string]
+
+Options:
+      --json             Output the data as JSON  [boolean] [default: false]
+      --short            Output data as text  [boolean] [default: false]
+  -u, --instance, --url  Saleor instance to work with  [string]
+      --force            skip confirmation prompt  [boolean]
+  -V, --version          Show version number  [boolean]
+  -h, --help             Show help  [boolean]
+```
+
+#### environment show
+
+```sh
+$ saleor environment show --help
+```
+
+Help output:
+
+```
+saleor environment show [key|environment]
+
+Show a specific environment
+
+Positionals:
+  key, environment  key of the environment  [string]
+
+Options:
+      --json             Output the data as JSON  [boolean] [default: false]
+      --short            Output data as text  [boolean] [default: false]
+  -u, --instance, --url  Saleor instance to work with  [string]
+  -V, --version          Show version number  [boolean]
+  -h, --help             Show help  [boolean]
+```
+
+#### environment switch
+
+```sh
+$ saleor environment switch --help
+```
+
+Help output:
+
+```
+saleor environment switch [key|environment]
+
+Make the provided environment the default one
+
+Positionals:
+  key, environment  key of the environment  [string]
+
+Options:
+      --json             Output the data as JSON  [boolean] [default: false]
+      --short            Output data as text  [boolean] [default: false]
+  -u, --instance, --url  Saleor instance to work with  [string]
+  -V, --version          Show version number  [boolean]
+  -h, --help             Show help  [boolean]
+```
+
+#### environment update
+
+```sh
+$ saleor environment update --help
+```
+
+Help output:
+
+```
+saleor environment update [key|environment]
+
+Update name of the environment
+
+Positionals:
+  key, environment  key of the environment  [string]
+
+Options:
+      --json             Output the data as JSON  [boolean] [default: false]
+      --short            Output data as text  [boolean] [default: false]
+  -u, --instance, --url  Saleor instance to work with  [string]
+      --name             name of the environment  [string]
+  -V, --version          Show version number  [boolean]
+  -h, --help             Show help  [boolean]
+
+Examples:
+  saleor env update
+  saleor env update my-environment
+  saleor env update my-environment --name=renamed-env
+```
+
+#### environment upgrade
+
+```sh
+$ saleor environment upgrade --help
+```
+
+Help output:
+
+```
+saleor environment upgrade [key|environment]
+
+Upgrade a Saleor version in a specific environment
+
+Positionals:
+  key, environment  key of the environment  [string]
+
+Options:
+      --json             Output the data as JSON  [boolean] [default: false]
+      --short            Output data as text  [boolean] [default: false]
+  -u, --instance, --url  Saleor instance to work with  [string]
   -V, --version          Show version number  [boolean]
   -h, --help             Show help  [boolean]
 ```

--- a/src/cli/env/auth.ts
+++ b/src/cli/env/auth.ts
@@ -1,0 +1,105 @@
+import Debug from 'debug';
+import type { Arguments, CommandBuilder } from 'yargs';
+
+import Enquirer from 'enquirer';
+import { API, PATCH } from '../../lib/index.js';
+import {
+  obfuscateArgv,
+  println,
+  printlnSuccess,
+  validateLength,
+} from '../../lib/util.js';
+import {
+  useBlockingTasksChecker,
+  useEnvironment,
+} from '../../middleware/index.js';
+import { Options } from '../../types.js';
+import { getEnvironment } from '../../lib/environment.js';
+
+const debug = Debug('saleor-cli:env:auth');
+
+export const command = 'auth [key|environment]';
+export const desc = 'Manage basic auth for a specific environment';
+
+export const builder: CommandBuilder = (_) =>
+  _.positional('key', {
+    type: 'string',
+    demandOption: false,
+    desc: 'key of the environment',
+  })
+    .option('login', {
+      type: 'string',
+      demandOption: false,
+      desc: 'basic auth login of the environment',
+    })
+    .option('password', {
+      alias: 'pass',
+      type: 'string',
+      demandOption: false,
+      desc: 'basic auth password of the environment',
+    })
+    .option('disable', {
+      type: 'boolean',
+      demandOption: false,
+      desc: 'disable basic auth for the environment',
+    })
+    .example('saleor env auth', '')
+    .example('saleor env auth my-environment', '')
+    .example(
+      'saleor env auth my-environment --login=saleor --password=saleor',
+      '',
+    )
+    .example('saleor env auth my-environment --disable', '');
+
+export const handler = async (argv: Arguments<Options>) => {
+  debug('command arguments: %O', obfuscateArgv(argv));
+
+  const environment = await getEnvironment(argv);
+
+  if (argv.disable) {
+    if (!environment.protected) {
+      println('Basic auth is already disabled for this environment');
+      return;
+    }
+
+    await PATCH(API.Environment, argv, {
+      json: {
+        login: null,
+        password: null,
+      },
+    });
+
+    printlnSuccess('Basic auth is disabled');
+    return;
+  }
+
+  const json = await Enquirer.prompt<{
+    login: string;
+    password: string;
+  }>([
+    {
+      type: 'input',
+      name: 'login',
+      message: 'Login',
+      initial: argv.login,
+      skip: !!argv.login,
+      validate: (value) => validateLength(value, 127, 'login', true),
+    },
+    {
+      type: 'password',
+      name: 'password',
+      message: 'Password',
+      initial: argv.password,
+      skip: !!argv.password,
+      validate: (value) => validateLength(value, 127, 'password', true),
+    },
+  ]);
+
+  await PATCH(API.Environment, argv, {
+    json,
+  });
+
+  printlnSuccess('Basic auth is enabled');
+};
+
+export const middlewares = [useEnvironment, useBlockingTasksChecker];

--- a/src/cli/env/index.ts
+++ b/src/cli/env/index.ts
@@ -1,25 +1,31 @@
 import { useOrganization, useToken } from '../../middleware/index.js';
+import * as auth from './auth.js';
 import * as cleardb from './clear.js';
 import * as create from './create.js';
 import * as list from './list.js';
+import * as maintenance from './maintenance.js';
 import * as populatedb from './populate.js';
 import * as promote from './promote.js';
 import * as remove from './remove.js';
 import * as show from './show.js';
 import * as change from './switch.js'; // `switch` is a JavaScript keyword
+import * as update from './update.js';
 import * as upgrade from './upgrade.js';
 
 export default function (_: any) {
   _.command([
-    show,
-    list,
-    create,
-    change,
-    remove,
-    upgrade,
+    auth,
     cleardb,
+    create,
+    list,
+    maintenance,
     populatedb,
     promote,
+    remove,
+    show,
+    change,
+    update,
+    upgrade,
   ])
     .middleware([useToken, useOrganization])
     .demandCommand(1, 'You need at least one command before moving on');

--- a/src/cli/env/maintenance.ts
+++ b/src/cli/env/maintenance.ts
@@ -1,0 +1,88 @@
+import Debug from 'debug';
+import type { Arguments, CommandBuilder } from 'yargs';
+
+import Enquirer from 'enquirer';
+import { getEnvironment } from '../../lib/environment.js';
+import { API, PATCH } from '../../lib/index.js';
+import { obfuscateArgv, println, printlnSuccess } from '../../lib/util.js';
+import {
+  useBlockingTasksChecker,
+  useEnvironment,
+} from '../../middleware/index.js';
+import { EnvironmentMaintenance } from '../../types.js';
+
+const debug = Debug('saleor-cli:env:maintanance');
+
+export const command = 'maintenance [key|environment]';
+export const desc =
+  'Enable or disable maintenance mode in a specific environment';
+
+export const builder: CommandBuilder = (_) =>
+  _.positional('key', {
+    type: 'string',
+    demandOption: false,
+    desc: 'key of the environment',
+  })
+    .option('enable', {
+      type: 'boolean',
+      demandOption: false,
+      desc: 'enable maintenance mode',
+    })
+    .option('disable', {
+      type: 'boolean',
+      demandOption: false,
+      desc: 'disable maintenance mode',
+    })
+    .example('saleor env maintenance', '')
+    .example('saleor env maintenance my-environment', '')
+    .example('saleor env maintenance my-environment --enable', '')
+    .example('saleor env maintenance my-environment --disable', '');
+
+export const handler = async (argv: Arguments<EnvironmentMaintenance>) => {
+  debug('command arguments: %O', obfuscateArgv(argv));
+  const { enable, disable } = argv;
+
+  if (disable !== undefined) {
+    await updateEnvironment(argv, { maintenance_mode: false });
+  }
+
+  if (enable !== undefined) {
+    await updateEnvironment(argv, { maintenance_mode: true });
+  }
+
+  const { maintenanceMode } = await Enquirer.prompt<{
+    maintenanceMode: boolean;
+  }>({
+    type: 'select',
+    name: 'maintenanceMode',
+    choices: [
+      { message: 'disable maintenance mode', name: '', value: false },
+      { message: 'enable maintenance mode', name: 'true', value: true },
+    ],
+    message: 'Choose an option',
+  });
+
+  await updateEnvironment(argv, { maintenance_mode: Boolean(maintenanceMode) });
+};
+
+const updateEnvironment = async (
+  argv: Arguments<EnvironmentMaintenance>,
+  json: { maintenance_mode: boolean },
+) => {
+  const { maintenance_mode: maintenanceMode } = await getEnvironment(argv);
+  const mode = json.maintenance_mode ? 'enabled' : 'disabled';
+
+  if (maintenanceMode === json.maintenance_mode) {
+    println(`Maintenance mode is already ${mode}`);
+    process.exit(0);
+  }
+
+  await PATCH(API.Environment, argv, {
+    json,
+  });
+
+  printlnSuccess(`Maintenance mode is ${mode}`);
+  process.exit(0);
+};
+
+export const middlewares = [useEnvironment, useBlockingTasksChecker];

--- a/src/cli/env/update.ts
+++ b/src/cli/env/update.ts
@@ -1,0 +1,63 @@
+import Debug from 'debug';
+import type { Arguments, CommandBuilder } from 'yargs';
+
+import Enquirer from 'enquirer';
+import { getEnvironment } from '../../lib/environment.js';
+import { API, PATCH } from '../../lib/index.js';
+import {
+  obfuscateArgv,
+  printlnSuccess,
+  validateLength,
+} from '../../lib/util.js';
+import {
+  useBlockingTasksChecker,
+  useEnvironment,
+} from '../../middleware/index.js';
+import { Options } from '../../types.js';
+
+const debug = Debug('saleor-cli:env:update');
+
+export const command = 'update [key|environment]';
+export const desc = 'Update name of the environment';
+
+export const builder: CommandBuilder = (_) =>
+  _.positional('key', {
+    type: 'string',
+    demandOption: false,
+    desc: 'key of the environment',
+  })
+    .option('name', {
+      type: 'string',
+      demandOption: false,
+      desc: 'name of the environment',
+    })
+    .example('saleor env update', '')
+    .example('saleor env update my-environment', '')
+    .example('saleor env update my-environment --name=renamed-env', '');
+
+export const handler = async (argv: Arguments<Options>) => {
+  debug('command arguments: %O', obfuscateArgv(argv));
+
+  const environment = await getEnvironment(argv);
+
+  const json = await Enquirer.prompt<{
+    name: string;
+  }>([
+    {
+      type: 'input',
+      name: 'name',
+      message: 'name',
+      initial: argv.name || environment.name,
+      validate: (value) => validateLength(value, 255),
+      skip: !!argv.name,
+    },
+  ]);
+
+  await PATCH(API.Environment, argv, {
+    json,
+  });
+
+  printlnSuccess('Environment update triggered');
+};
+
+export const middlewares = [useEnvironment, useBlockingTasksChecker];

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -75,11 +75,14 @@ const doDELETERequest = (path: string, options?: OptionsOfTextResponseBody) =>
   got.delete(path, { ...options }).json();
 const doPUTRequest = (path: string, options?: OptionsOfTextResponseBody) =>
   got.put(path, { ...options }).json();
+const doPATCHRequest = (path: string, options?: OptionsOfTextResponseBody) =>
+  got.patch(path, { ...options }).json();
 
 export const GET = handleAuthAndConfig(doGETRequest);
 export const POST = handleAuthAndConfig(doPOSTRequest);
 export const PUT = handleAuthAndConfig(doPUTRequest);
 export const DELETE = handleAuthAndConfig(doDELETERequest);
+export const PATCH = handleAuthAndConfig(doPATCHRequest);
 
 export const API: Record<string, DefaultURLPath> = {
   User: () => 'user',

--- a/src/types.ts
+++ b/src/types.ts
@@ -107,6 +107,14 @@ export interface Environment {
   maintenance_mode: boolean;
   blocking_tasks_in_progress: boolean;
   disabled: boolean;
+  allowed_client_origins: string[];
+  allowed_cors_origins: null | string | string[];
+  protected: boolean;
+}
+
+export interface EnvironmentMaintenance extends BaseOptions {
+  enable?: boolean;
+  disable?: boolean;
 }
 
 export interface Task {

--- a/test/__snapshots__/vercel.test.ts.snap
+++ b/test/__snapshots__/vercel.test.ts.snap
@@ -1,4 +1,4 @@
-// Vitest Snapshot v1
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Vercel API > snapshot 1`] = `
 {

--- a/test/functional/environment/show.test.ts
+++ b/test/functional/environment/show.test.ts
@@ -1,4 +1,4 @@
-import { beforeAll, describe, expect, it } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import {
   DefaultTriggerResponse,
@@ -6,10 +6,6 @@ import {
   testOrganization,
   trigger,
 } from '../../helper';
-
-beforeAll(async () => {
-  await prepareEnvironment();
-});
 
 describe('storefront show', async () => {
   const command = 'saleor';

--- a/test/functional/environment/update.test.ts
+++ b/test/functional/environment/update.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  command,
+  DefaultTriggerResponse,
+  prepareEnvironment,
+  shouldMockTests,
+  testOrganization,
+  trigger,
+} from '../../helper';
+import { API, GET } from '../../../src/lib/index.js';
+import { Environment } from '../../../src/types.js';
+
+const newName = 'updated-name';
+
+const getEnvironment = async (envKey: string) => {
+  if (shouldMockTests) {
+    return {
+      key: envKey,
+      name: newName,
+      maintenance_mode: true,
+      protected: true,
+    };
+  }
+
+  const environment = await (GET(API.Environment, {
+    environment: envKey,
+    organization: testOrganization,
+  }) as Promise<Environment>);
+
+  return environment;
+};
+
+describe('update environment', async () => {
+  const envKey = await prepareEnvironment();
+
+  it(
+    '`env update` updates the environment name',
+    async () => {
+      const params = [
+        'env',
+        'update',
+        envKey,
+        `--name=${newName}`,
+        `--organization=${testOrganization}`,
+      ];
+
+      const { exitCode } = await trigger(
+        command,
+        params,
+        {},
+        {
+          ...DefaultTriggerResponse,
+        },
+      );
+      expect(exitCode).toBe(0);
+
+      const environment = await getEnvironment(envKey);
+      expect(environment.name).toBe(newName);
+    },
+    1000 * 60 * 10,
+  );
+
+  it('`env maintenance` enables the maintenance mode', async () => {
+    const params = [
+      'environment',
+      'maintenance',
+      '--enable',
+      `--organization=${testOrganization}`,
+    ];
+
+    const { exitCode } = await trigger(
+      command,
+      params,
+      {},
+      {
+        ...DefaultTriggerResponse,
+      },
+    );
+    expect(exitCode).toBe(0);
+
+    const environment = await getEnvironment(envKey);
+    expect(environment.maintenance_mode).toBeTruthy();
+  });
+
+  it('`env auth` enables the basic auth on the environment', async () => {
+    const params = [
+      'env',
+      'auth',
+      envKey,
+      '--login=saleor',
+      '--password=saleor',
+      `--organization=${testOrganization}`,
+    ];
+
+    const { exitCode } = await trigger(
+      command,
+      params,
+      {},
+      {
+        ...DefaultTriggerResponse,
+      },
+    );
+    expect(exitCode).toBe(0);
+
+    const environment = await getEnvironment(envKey);
+    expect(environment.protected).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## I want to merge this PR because 

This PR introduces additional commands for environment management. It adds 
- `saleor env update` to edit environment name
- `saleor env auth` to manage basic auth protection on the environment
- `saleor env maintenance` to manage maintenance mode on the environment  

## Related (issues, PRs, topics)

- #679

## Steps to test feature

- `saleor env update`
- `saleor env auth`
- `saleor env maintenance`

## I have:

- [x] Tested it locally and it doesn't break existing features
- [x] Added documentation if public changes are introduced
- [x] Added tests for my code 
