### PR TITLE
Fix `env maintenance` prompt

### DIFF
--- a/src/cli/env/maintenance.ts
+++ b/src/cli/env/maintenance.ts
@@ -51,18 +51,20 @@ export const handler = async (argv: Arguments<EnvironmentMaintenance>) => {
   }
 
   const { maintenanceMode } = await Enquirer.prompt<{
-    maintenanceMode: boolean;
+    maintenanceMode: string;
   }>({
     type: 'select',
     name: 'maintenanceMode',
     choices: [
-      { message: 'disable maintenance mode', name: '', value: false },
-      { message: 'enable maintenance mode', name: 'true', value: true },
+      { message: 'disable maintenance mode', name: 'disable' },
+      { message: 'enable maintenance mode', name: 'enable' },
     ],
     message: 'Choose an option',
   });
 
-  await updateEnvironment(argv, { maintenance_mode: Boolean(maintenanceMode) });
+  await updateEnvironment(argv, {
+    maintenance_mode: maintenanceMode === 'enable',
+  });
 };
 
 const updateEnvironment = async (

--- a/test/functional/environment/auth.test.ts
+++ b/test/functional/environment/auth.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, afterAll } from 'vitest';
+
+import {
+  cleanEnvAfterUpdate,
+  command,
+  DefaultTriggerResponse,
+  getEnvironment,
+  prepareEnvironment,
+  testOrganization,
+  trigger,
+  waitForBlockingTasks,
+  removeEnvironment,
+} from '../../helper';
+
+const envKey = await prepareEnvironment();
+
+afterAll(async () => removeEnvironment(envKey));
+
+describe('update auth in environment', async () => {
+  await waitForBlockingTasks(envKey);
+
+  it('`env auth` enables the basic auth on the environment', async () => {
+    const params = [
+      'env',
+      'auth',
+      envKey,
+      '--login=saleor',
+      '--password=saleor',
+      `--organization=${testOrganization}`,
+    ];
+
+    const { exitCode } = await trigger(
+      command,
+      params,
+      {},
+      {
+        ...DefaultTriggerResponse,
+      },
+    );
+    expect(exitCode).toBe(0);
+
+    const environment = await getEnvironment(envKey);
+    expect(environment.protected).toBeTruthy();
+  });
+
+  await cleanEnvAfterUpdate(envKey);
+});

--- a/test/functional/environment/maintenance.test.ts
+++ b/test/functional/environment/maintenance.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, afterAll } from 'vitest';
+
+import {
+  cleanEnvAfterUpdate,
+  command,
+  DefaultTriggerResponse,
+  getEnvironment,
+  prepareEnvironment,
+  testOrganization,
+  trigger,
+  waitForBlockingTasks,
+  removeEnvironment,
+} from '../../helper';
+
+const envKey = await prepareEnvironment();
+
+afterAll(async () => removeEnvironment(envKey));
+
+describe('update maintenance mode in the environment', async () => {
+  await waitForBlockingTasks(envKey);
+
+  it('`env maintenance` enables the maintenance mode', async () => {
+    const params = [
+      'env',
+      'maintenance',
+      envKey,
+      '--enable',
+      `--organization=${testOrganization}`,
+    ];
+
+    const { exitCode } = await trigger(
+      command,
+      params,
+      {},
+      {
+        ...DefaultTriggerResponse,
+      },
+    );
+    expect(exitCode).toBe(0);
+
+    const environment = await getEnvironment(envKey);
+    expect(environment.maintenance_mode).toBeTruthy();
+  });
+
+  await cleanEnvAfterUpdate(envKey);
+});


### PR DESCRIPTION
## I want to merge this PR because 

- it fixes the prompt logic for the prompt in the `env maintenance` command
- it reorganizes the tests connected with environment update

## Related (issues, PRs, topics)

- NA

## Steps to test feature

- `saleor env maintenance`

## I have:

- [x] Tested it locally and it doesn't break existing features
- [ ] Added documentation if public changes are introduced
- [x] Added tests for my code
