### PR TITLE
chore: update pnpm settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saleor/cli",
-  "version": "0.0.0",
+  "version": "1.42.1",
   "description": "",
   "type": "module",
   "repository": "github:saleor/saleor-cli",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "saleor-cli",
-  "version": "1.42.1",
+  "name": "@saleor/cli",
+  "version": "0.0.0",
   "description": "",
   "type": "module",
   "repository": "github:saleor/saleor-cli",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@saleor/cli",
+  "name": "saleor-cli",
   "version": "1.42.1",
   "description": "",
   "type": "module",
@@ -123,7 +123,7 @@
     "node": "^20 || ^22",
     "pnpm": ">=10.0.0 <11.0.0"
   },
-  "packageManager": "pnpm@10.11.0",
+  "packageManager": "pnpm@10.28.1",
   "pnpm": {
     "overrides": {
       "uuid": "8.3.2"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+blockExoticSubdeps: true
+minimumReleaseAge: 1440 # 24h
+trustPolicy: no-downgrade


### PR DESCRIPTION
## Summary
- Update pnpm to version 10.28.1
- Add pnpm-workspace.yaml security settings:
  - `blockExoticSubdeps: true`
  - `minimumReleaseAge: 1440` (24h)
  - `trustPolicy: no-downgrade`